### PR TITLE
Compress Analysis Includes

### DIFF
--- a/DoStandaloneCorrelatorCalculation.cxx
+++ b/DoStandaloneCorrelatorCalculation.cxx
@@ -14,17 +14,17 @@
 #include <vector>
 #include <cstdlib>
 #include <utility>
-// analysis utilities
-#include "/sphenix/user/danderson/install/include/senergycorrelator/SEnergyCorrelator.h"
-#include "/sphenix/user/danderson/install/include/senergycorrelator/SEnergyCorrelatorConfig.h"
+// module definition
+#include <senergycorrelator/SEnergyCorrelator.h>
+// macro options
 #include "EnergyCorrelatorOptions.h"
 
 using namespace std;
 using namespace SColdQcdCorrelatorAnalysis;
 
 // load libraries
-R__LOAD_LIBRARY(/sphenix/user/danderson/install/lib/libsenergycorrelator.so)
-R__LOAD_LIBRARY(/sphenix/user/danderson/install/lib/libscorrelatorutilities.so)
+R__LOAD_LIBRARY(libsenergycorrelator.so)
+R__LOAD_LIBRARY(libscorrelatorutilities.so)
 
 
 

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -14,9 +14,10 @@
 #include <utility>
 #include <optional>
 // analysis utilities
-#include "/sphenix/user/atclarke/install/include/scorrelatorutilities/Types.h"
-#include "/sphenix/user/atclarke/install/include/scorrelatorutilities/Constants.h"
-#include "/sphenix/user/atclarke/install/include/senergycorrelator/SEnergyCorrelatorConfig.h"
+#include <scorrelatorutilities/Types.h>
+#include <scorrelatorutilities/Constants.h>
+// module configuration
+#include <senergycorrelator/SEnergyCorrelatorConfig.h>
 
 // make common namespacs implicit
 using namespace std;

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -40,12 +40,12 @@
 // fastjet libraries
 #include <fastjet/PseudoJet.hh>
 // eec library
-#include "/sphenix/user/danderson/eec/EnergyEnergyCorrelators/eec/include/EECLongestSide.hh"
+#include "eec/EECLongestSide.hh"
 // analysis utilities
-#include "/sphenix/user/atclarke/install/include/scorrelatorutilities/Tools.h"
-#include "/sphenix/user/atclarke/install/include/scorrelatorutilities/Types.h"
-#include "/sphenix/user/atclarke/install/include/scorrelatorutilities/Constants.h"
-#include "/sphenix/user/atclarke/install/include/scorrelatorutilities/Interfaces.h"
+#include <scorrelatorutilities/Tools.h>
+#include <scorrelatorutilities/Types.h>
+#include <scorrelatorutilities/Constants.h>
+#include <scorrelatorutilities/Interfaces.h>
 // analysis definitions
 #include "SEnergyCorrelatorInput.h"
 #include "SEnergyCorrelatorConfig.h"


### PR DESCRIPTION
This PR compresses the paths of all analysis-specific included headers and dynamic libraries. This will require the user to ensure a couple things before running the driver macro.

First, to make sure ACLiC picks up the dynamic library, `LD_LIBRARY_PATH` needs to include the path the to the user's install area. For example, adding this line to one's startup script will ensure this:

```
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MYINSTALL/lib
```

Then, to make sure ROOT's interpreter knows where to find included to headers, the following line should be added to one's `.rootlogon.C` (or equivalent) macro:

```
gInterpreter -> AddIncludePath("<path-to-install>/include");
```

And lastly, the following line needs to be added to one's `.rootrc`

```
Rint.Logon: $(HOME)/.rootlogon.C
```

(Where `$(HOME)/.rootlogon.C` can be replaced by the path to the relevant macro.)