### PR TITLE
Add hooks for non-legacy input tree

### DIFF
--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -56,9 +56,11 @@ namespace SColdQcdCorrelatorAnalysis {
     m_fCurrent = -1;
     m_inChain -> SetMakeClass(1);
 
-    // set truth vs. reco branch addresses
+    // set input tree
     if (m_config.isLegacyInput) {
       m_legacy.SetChainAddresses(m_inChain, m_config.isInTreeTruth);
+    } else {
+      m_input.SetChainAddresses(m_inChain, m_config.isInTreeTruth);
     }
 
     // announce tree setting

--- a/src/SEnergyCorrelatorInput.h
+++ b/src/SEnergyCorrelatorInput.h
@@ -38,6 +38,11 @@ namespace SColdQcdCorrelatorAnalysis {
       return;
     }  // end 'Reset()'
 
+    void SetChainAddresses(TChain* chain, const bool isInTreeTruth = true) {
+      /* TODO fill in */
+      return;
+    }  // end 'SetChainAddresses(TChain*, bool)'
+
   };  // end SEnergyCorrelatorInput 
 
 


### PR DESCRIPTION
This PR adds the hooks for setting non-legacy input tree addresses. The details will be filled in in a later PR.