### PR TITLE
added E3C calculation

### DIFF
--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -72,7 +72,7 @@ namespace EnergyCorrelatorOptions {
   //Manual calculation option
   const bool doManualCalc = true;
   const bool doThreePoint = true;
-  const double targetRL = 0.25;
+  const vector <pair<double, double>> RL_Bins = {{0.0, 0.22664}, {0.22664, 0.26666}, {0.26666, 1.0}};
   const int mom_option = 0;
   const int norm_option = 0;
   
@@ -144,7 +144,7 @@ namespace EnergyCorrelatorOptions {
       .ptJetBins     = ptJetBins,
       .doManualCalc = doManualCalc,
       .doThreePoint = doThreePoint,
-      .targetRL = targetRL,
+      .RL_Bins = RL_Bins,
       .mom_option = mom_option,
       .norm_option = norm_option,
       .jetAccept     = GetJetAccept(),
@@ -182,7 +182,7 @@ namespace EnergyCorrelatorOptions {
       .ptJetBins     = ptJetBins,
       .doManualCalc = doManualCalc,
       .doThreePoint = doThreePoint,
-      .targetRL = targetRL,
+      .RL_Bins = RL_Bins,
       .mom_option = mom_option,
       .norm_option = norm_option,
       .jetAccept     = GetJetAccept(),

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -71,6 +71,8 @@ namespace EnergyCorrelatorOptions {
 
   //Manual calculation option
   const bool doManualCalc = true;
+  const bool doThreePoint = true;
+  const double targetRL = 0.25;
   const int mom_option = 0;
   const int norm_option = 0;
   
@@ -141,6 +143,8 @@ namespace EnergyCorrelatorOptions {
       .drBinRange    = binRangeDr,
       .ptJetBins     = ptJetBins,
       .doManualCalc = doManualCalc,
+      .doThreePoint = doThreePoint,
+      .targetRL = targetRL,
       .mom_option = mom_option,
       .norm_option = norm_option,
       .jetAccept     = GetJetAccept(),
@@ -177,6 +181,8 @@ namespace EnergyCorrelatorOptions {
       .drBinRange    = binRangeDr,
       .ptJetBins     = ptJetBins,
       .doManualCalc = doManualCalc,
+      .doThreePoint = doThreePoint,
+      .targetRL = targetRL,
       .mom_option = mom_option,
       .norm_option = norm_option,
       .jetAccept     = GetJetAccept(),

--- a/src/SEnergyCorrelator.ana.h
+++ b/src/SEnergyCorrelator.ana.h
@@ -169,20 +169,6 @@ namespace SColdQcdCorrelatorAnalysis {
   void SEnergyCorrelator::DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, ROOT::Math::PtEtaPhiEVector normalization){
     //Get norm
     double norm = GetWeight(normalization, m_config.norm_option);
-    //If necessary get required RL range for E3C
-    double dRLow = 0.0;
-    double dRHigh = m_config.targetRL + 0.25;
-    if(m_config.doThreePoint){
-      for(size_t iDr = 0; iDr < m_config.nBinsDr-1; iDr++){
-	if(m_outManualHistErrDrAxis[0]->GetBinLowEdge(iDr) <= m_config.targetRL && iDr+1 < m_config.nBinsDr && m_outManualHistErrDrAxis[0]->GetBinLowEdge(iDr+1) >= m_config.targetRL){
-	  dRLow = m_outManualHistErrDrAxis[0]->GetBinLowEdge(iDr);
-	  dRHigh = m_outManualHistErrDrAxis[0]->GetBinLowEdge(iDr+1);
-	  if(iDr>0) dRLow = m_outManualHistErrDrAxis[0]->GetBinLowEdge(iDr-1);
-	  if(iDr+2<m_config.nBinsDr) dRHigh = m_outManualHistErrDrAxis[0]->GetBinLowEdge(iDr+2);
-	}
-      }
-    }
-    
     //Loop over csts
     for(uint64_t iCst = 0; iCst < momentum.size(); iCst++){
       //Get weightA
@@ -256,9 +242,6 @@ namespace SColdQcdCorrelatorAnalysis {
 	  //skip in case RS or RM are 0
 	  if(RS == 0 || RM == 0) continue;
 
-	  //Enforce RL conditon
-	  if(RL<dRLow || RL > dRHigh) continue;
-
 	  //Get Parameterization
 	  const double xi = RS/RM;
 	  const double phi = std::asin(sqrt(1 - pow(RL-RM, 2)/(RS*RS)));
@@ -267,7 +250,11 @@ namespace SColdQcdCorrelatorAnalysis {
 	  for(size_t iPtBin = 0; iPtBin < m_config.ptJetBins.size(); iPtBin++){
 	    bool isInPtBin = ((normalization.Pt() >= m_config.ptJetBins[iPtBin].first) && (normalization.Pt() < m_config.ptJetBins[iPtBin].second));
 	    if(isInPtBin){
-	      m_outE3C[iPtBin]->Fill(xi, phi, e3cWeight);
+	      for(size_t jRLBin = 0; jRLBin < m_config.RL_Bins.size(); jRLBin++){
+		if(RL >= m_config.RL_Bins[jRLBin].first && RL < m_config.RL_Bins[jRLBin].second){
+		  m_outE3C[iPtBin][jRLBin]->Fill(xi, phi, e3cWeight);
+		}
+	      }
 	    }
 	  }//end of ptBin loop
 	}//end of third cst loop

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -58,8 +58,10 @@ namespace SColdQcdCorrelatorAnalysis {
       delete m_outPackageHistVarLnDrAxis.at(iPtBin);
       delete m_outPackageHistErrLnDrAxis.at(iPtBin);
       delete m_outManualHistErrDrAxis.at(iPtBin);
-      delete m_outE3C.at(iPtBin);
       delete m_outProjE3C.at(iPtBin);
+      for(size_t jRLBin = 0; jRLBin < m_config.RL_Bins.size(); jRLBin++){
+	delete m_outE3C[iPtBin].at(jRLBin);
+      }
     }
     m_eecLongSide.clear();
     m_outPackageHistVarDrAxis.clear();

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -58,6 +58,8 @@ namespace SColdQcdCorrelatorAnalysis {
       delete m_outPackageHistVarLnDrAxis.at(iPtBin);
       delete m_outPackageHistErrLnDrAxis.at(iPtBin);
       delete m_outManualHistErrDrAxis.at(iPtBin);
+      delete m_outE3C.at(iPtBin);
+      delete m_outProjE3C.at(iPtBin);
     }
     m_eecLongSide.clear();
     m_outPackageHistVarDrAxis.clear();
@@ -65,6 +67,8 @@ namespace SColdQcdCorrelatorAnalysis {
     m_outPackageHistVarLnDrAxis.clear();
     m_outPackageHistErrLnDrAxis.clear();
     m_outManualHistErrDrAxis.clear();
+    m_outE3C.clear();
+    m_outProjE3C.clear();
 
   }  // end dtor
 

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -21,6 +21,7 @@
 #include <optional>
 // root libraries
 #include <TH1.h>
+#include <TH2.h>
 #include <TFile.h>
 #include <TChain.h>
 #include <TString.h>
@@ -40,7 +41,7 @@
 // fastjet libraries
 #include <fastjet/PseudoJet.hh>
 // eec library
-#include "eec/EECLongestSide.hh"
+#include "/sphenix/user/danderson/eec/EnergyEnergyCorrelators/eec/include/EECLongestSide.hh"
 // analysis utilities
 #include <scorrelatorutilities/Tools.h>
 #include <scorrelatorutilities/Types.h>
@@ -132,6 +133,8 @@ namespace SColdQcdCorrelatorAnalysis {
       vector<TH1D*> m_outPackageHistErrLnDrAxis;
 
       vector<TH1D*> m_outManualHistErrDrAxis;
+      vector<TH2D*> m_outE3C;
+      vector<TH1D*> m_outProjE3C;
 
       // correlators
       vector<fastjet::contrib::eec::EECLongestSide<fastjet::contrib::eec::hist::axis::log>*> m_eecLongSide;

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -41,7 +41,7 @@
 // fastjet libraries
 #include <fastjet/PseudoJet.hh>
 // eec library
-#include "/sphenix/user/danderson/eec/EnergyEnergyCorrelators/eec/include/EECLongestSide.hh"
+#include "/eec/include/EECLongestSide.hh"
 // analysis utilities
 #include <scorrelatorutilities/Tools.h>
 #include <scorrelatorutilities/Types.h>
@@ -133,7 +133,7 @@ namespace SColdQcdCorrelatorAnalysis {
       vector<TH1D*> m_outPackageHistErrLnDrAxis;
 
       vector<TH1D*> m_outManualHistErrDrAxis;
-      vector<TH2D*> m_outE3C;
+      vector<vector<TH2D*>> m_outE3C;
       vector<TH1D*> m_outProjE3C;
 
       // correlators

--- a/src/SEnergyCorrelator.io.h
+++ b/src/SEnergyCorrelator.io.h
@@ -92,8 +92,10 @@ namespace SColdQcdCorrelatorAnalysis {
       if(m_config.doManualCalc){
 	m_outManualHistErrDrAxis[iPtBin]->Write();
 	if(m_config.doThreePoint){
-	  m_outE3C[iPtBin]->Write();
 	  m_outProjE3C[iPtBin]->Write();
+	  for(size_t jRLBin = 0; jRLBin < m_config.RL_Bins.size(); jRLBin++){
+	    m_outE3C[iPtBin][jRLBin]->Write();
+	  }
 	}
       }
     }

--- a/src/SEnergyCorrelator.io.h
+++ b/src/SEnergyCorrelator.io.h
@@ -91,6 +91,10 @@ namespace SColdQcdCorrelatorAnalysis {
       m_outPackageHistErrLnDrAxis[iPtBin] -> Write();
       if(m_config.doManualCalc){
 	m_outManualHistErrDrAxis[iPtBin]->Write();
+	if(m_config.doThreePoint){
+	  m_outE3C[iPtBin]->Write();
+	  m_outProjE3C[iPtBin]->Write();
+	}
       }
     }
 

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -101,12 +101,18 @@ namespace SColdQcdCorrelatorAnalysis {
 	m_outManualHistErrDrAxis.push_back(new TH1D(weightNameTH1, "", m_config.nBinsDr, drBinEdgeArray));
 	m_outManualHistErrDrAxis[iPtBin]->Sumw2();
 	if(m_config.doThreePoint){
-	  TString E3CName("hManualE3C_ptJet");
 	  TString projE3CName("hManualProjE3C_ptJet");
-	  E3CName+=floor(m_config.ptJetBins[iPtBin].first);
 	  projE3CName+=floor(m_config.ptJetBins[iPtBin].first);
-	  m_outE3C.push_back(new TH2D(E3CName, "", 100, 0.0, 1.0, 100, 0.0, TMath::Pi()/2));
 	  m_outProjE3C.push_back(new TH1D(projE3CName, "", m_config.nBinsDr, drBinEdgeArray));
+	  vector<TH2D*> E3C_tmp;
+	  for(size_t jRLBin = 0; jRLBin<m_config.RL_Bins.size(); jRLBin++){
+	    TString E3CName("hManualE3C_ptJet");
+	    E3CName+=floor(m_config.ptJetBins[iPtBin].first);
+	    E3CName+="_RLBin";
+	    E3CName+=jRLBin;
+	    E3C_tmp.push_back(new TH2D(E3CName, "", 100, 0.0, 1.0, 100, 0.0, TMath::Pi()/2));
+	  }
+	  m_outE3C.push_back(E3C_tmp);
 	}
       }
     }

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -35,6 +35,8 @@ namespace SColdQcdCorrelatorAnalysis {
     m_outPackageHistVarLnDrAxis.clear();
     m_outPackageHistErrLnDrAxis.clear();
     m_outManualHistErrDrAxis.clear();
+    m_outE3C.clear();
+    m_outProjE3C.clear();
     
 
     return;
@@ -98,6 +100,14 @@ namespace SColdQcdCorrelatorAnalysis {
 	weightNameTH1+=floor(m_config.ptJetBins[iPtBin].first);
 	m_outManualHistErrDrAxis.push_back(new TH1D(weightNameTH1, "", m_config.nBinsDr, drBinEdgeArray));
 	m_outManualHistErrDrAxis[iPtBin]->Sumw2();
+	if(m_config.doThreePoint){
+	  TString E3CName("hManualE3C_ptJet");
+	  TString projE3CName("hManualProjE3C_ptJet");
+	  E3CName+=floor(m_config.ptJetBins[iPtBin].first);
+	  projE3CName+=floor(m_config.ptJetBins[iPtBin].first);
+	  m_outE3C.push_back(new TH2D(E3CName, "", 100, 0.0, 1.0, 100, 0.0, TMath::Pi()/2));
+	  m_outProjE3C.push_back(new TH1D(projE3CName, "", m_config.nBinsDr, drBinEdgeArray));
+	}
       }
     }
 

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -54,7 +54,7 @@ namespace SColdQcdCorrelatorAnalysis {
     //Manual Calculation option
     bool doManualCalc = false;
     bool doThreePoint = false;
-    double targetRL = 0.25; 
+    vector<pair<double, double>> RL_Bins = {{0.0, 1.0}};
     int mom_option = 0;
     int norm_option = 0;
 

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -53,6 +53,8 @@ namespace SColdQcdCorrelatorAnalysis {
 
     //Manual Calculation option
     bool doManualCalc = false;
+    bool doThreePoint = false;
+    double targetRL = 0.25; 
     int mom_option = 0;
     int norm_option = 0;
 


### PR DESCRIPTION
Modified code to support E3C and projected E3C calculations. Added two variables to the config: a boolean called doThreePoint which determines if the three point calculation is done and a double called targetRL which is the value of RL that all triplets pushed to the E3C must have RL around, it generally sets the RL range to be within +/- 2 dR bins of the target RL.