### PR TITLE
Prepare for TEEC: accreditation, clean up, slight refactor, and more 

### DIFF
--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -50,13 +50,20 @@ namespace EnergyCorrelatorOptions {
   const bool doThreePoint = false;
 
   // smearing options
-  //   - FIXME theta should be thetaSmear
-  const bool  modCsts    = true;
-  const bool  modJets    = true;
-  const float effVal     = 1;
-  const float theta      = 0;
-  const float ptCstSmear = 0.02;
-  const float ptJetSmear = 0.02;
+  //   - FIXME theta should be thSmear
+  //   - FIXME modJets should be doJetSmear
+  //   - FIXME modCsts should be doCstSmear
+  const bool   modJets    = true;
+  const bool   modCsts    = true;
+  const float  theta      = 0;
+  const float  ptCstSmear = 0.02;
+  const float  ptJetSmear = 0.02;
+
+  // efficiency options
+  const bool   doCstEff    = true;
+  const float  effValue    = 0.9;
+  const float  effSmooth   = 4.0;
+  const string effFunction = "[0]*(1.0-TMath::Exp(-1.0*[1]*x))";
 
   // jet pT bins
   const vector<pair<double, double>> ptJetBins = {
@@ -86,6 +93,22 @@ namespace EnergyCorrelatorOptions {
   const pair<float, float> eneCstRange = {0.1, 100.};
 
 
+
+  // create constituent efficiency function ===================================
+
+  TF1* MakeEffFunction() {
+
+    TF1* eff = new TF1(
+      "fCstEfficiency",
+      effFunction.data(),
+      eneCstRange.first,
+      eneCstRange.second
+    );
+    eff -> SetParameter(0, effValue);
+    eff -> SetParameter(1, effSmooth);
+    return eff;
+
+  }  // end 'MakeEffFunction()'
 
   
   // bundle acceptances into pairs ============================================
@@ -209,12 +232,14 @@ namespace EnergyCorrelatorOptions {
       .normOption    = normOption,
       .jetAccept     = GetJetAccept(),
       .cstAccept     = GetCstAccept(),
+      .modJets       = modJets,
       .modCsts       = modCsts,
+      .doCstEff      = doCstEff
       .theta         = theta,
-      .effVal        = effVal,
       .ptCstSmear    = ptCstSmear,
       .modJets       = modJets,
-      .ptJetSmear    = ptJetSmear
+      .ptJetSmear    = ptJetSmear,
+      .funcEff       = MakeEffFunction()
     };
     return cfg_true;
 

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -43,11 +43,14 @@ namespace EnergyCorrelatorOptions {
   const bool doDebug   = true;
   const bool doBatch   = false;
 
-  // manual calculation option
-  const int  momOption    = 0;
-  const int  normOption   = 0;
-  const bool doManualCalc = false;
-  const bool doThreePoint = false;
+  // calculation options
+  const int  momOption     = 0;
+  const int  normOption    = 0;
+  const bool doLocalCalc   = true;
+  const bool doGlobalCalc  = true;
+  const bool doManualCalc  = false;
+  const bool doPackageCalc = true;
+  const bool doThreePoint  = false;
 
   // smearing options
   const bool   doJetSmear      = true;
@@ -188,7 +191,10 @@ namespace EnergyCorrelatorOptions {
       .nBinsDr       = nBinsDr,
       .drBinRange    = binRangeDr,
       .ptJetBins     = ptJetBins,
+      .doLocalCalc   = doLocalCalc,
+      .doGlobalCalc  = doGlobalCalc,
       .doManualCalc  = doManualCalc,
+      .doPackageCalc = doPackageCalc,
       .doThreePoint  = doThreePoint,
       .rlBins        = rlBins,
       .momOption     = momOption,
@@ -228,7 +234,10 @@ namespace EnergyCorrelatorOptions {
       .nBinsDr         = nBinsDr,
       .drBinRange      = binRangeDr,
       .ptJetBins       = ptJetBins,
+      .doLocalCalc     = doLocalCalc,
+      .doGlobalCalc    = doGlobalCalc,
       .doManualCalc    = doManualCalc,
+      .doPackageCalc   = doPackageCalc,
       .doThreePoint    = doThreePoint,
       .rlBins          = rlBins,
       .momOption       = momOption,

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -1,10 +1,11 @@
-// ----------------------------------------------------------------------------
-// 'EnergyCorrelatorOptions.h'
-// Derek Anderson
-// 02.08.2024
-//
-// Options for the SEnergyCorrelator module.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    EnergyCorrelatorOptions.h
+ *  \authors Derek Anderson, Alex Clarke
+ *  \date    02.08.2024
+ *
+ *  Options for the SEnergyCorrelator module.
+ */
+/// ---------------------------------------------------------------------------
 
 #ifndef ENERGYCORRELATOROPTIONS_H
 #define ENERGYCORRELATOROPTIONS_H 
@@ -27,12 +28,26 @@ using namespace SColdQcdCorrelatorAnalysis;
 
 namespace EnergyCorrelatorOptions {
 
-  // options ------------------------------------------------------------------
+  // calculation options ======================================================
 
-  // correlator parameters
+  // general correlator parameters
   const vector<uint32_t>     nPoints    = {2};
   const pair<double, double> binRangeDr = {1e-5, 1.};
   const uint64_t             nBinsDr    = 75;
+
+  // basic options
+  const int  verbosity = 0;
+  const int  subEvtOpt = Const::SubEvtOpt::Everything;
+  const bool isEmbed   = false;
+  const bool doCstCuts = true;
+  const bool doDebug   = false;
+  const bool doBatch   = false;
+
+  // manual calculation option
+  const bool doManualCalc = false;
+  const bool doThreePoint = false;
+  const int  momOption   = 0;
+  const int  normOption  = 0;
 
   // jet pT bins
   const vector<pair<double, double>> ptJetBins = {
@@ -45,14 +60,22 @@ namespace EnergyCorrelatorOptions {
     {50., 100.}
   };
 
-  // misc options
-  const int  verbosity = 0;
-  const int  subEvtOpt = Const::SubEvtOpt::Everything;
-  const bool isEmbed   = false;
-  const bool doCstCuts = true;
-  const bool doDebug   = false;
-  const bool doBatch   = false;
-  const bool isLegacy  = true;
+  // rl bins for for manual E3C calc
+  const vector<pair<double, double>> rlBins = {
+    {0.0,     0.22664},
+    {0.22664, 0.26666},
+    {0.26666, 1.0}
+  };
+
+  // smearing options
+  const bool  modCsts    = true;
+  const bool  modJets    = true;
+  const float theta      = 0;
+  const float ptCstSmear    = 0.02;
+  const float effVal     = 1;
+  const float ptJetSmear = 0.02;
+
+  // acceptance cuts ==========================================================
 
   // jet acceptance
   const pair<float, float> etaJetRange = {-0.7, 0.7};
@@ -61,29 +84,14 @@ namespace EnergyCorrelatorOptions {
   const pair<float, float> drCstRange  = {0.,  100.};
   const pair<float, float> eneCstRange = {0.1, 100.};
 
-  // smearing options
-  const bool  modCsts    = true;
-  const bool  modJets    = true;
-  const float theta      = 0;
-  const float pTSmear    = 0.02;
-  const float effVal     = 1;
-  const float jetPtSmear = 0.02;
 
-  // manual calculation option
-  const bool doManualCalc = true;
-  const bool doThreePoint = true;
-  const int  mom_option   = 0;
-  const int  norm_option  = 0;
 
-  // rl bins for for manual E3C calc
-  const vector<pair<double, double>> RL_Bins = {
-    {0.0,     0.22664},
-    {0.22664, 0.26666},
-    {0.26666, 1.0}
-  };
   
-  // bundle acceptances into pairs --------------------------------------------
+  // bundle acceptances into pairs ============================================
 
+  // --------------------------------------------------------------------------
+  //! Bundle jet acceptance cuts into a pair
+  // --------------------------------------------------------------------------
   pair<Types::JetInfo, Types::JetInfo> GetJetAccept() {
 
     // create maximal range
@@ -103,6 +111,9 @@ namespace EnergyCorrelatorOptions {
 
 
 
+  // --------------------------------------------------------------------------
+  //! Bundle constituent acceptance cuts into a pair
+  // --------------------------------------------------------------------------
   pair<Types::CstInfo, Types::CstInfo> GetCstAccept() {
 
    // create maxmimal range
@@ -122,8 +133,11 @@ namespace EnergyCorrelatorOptions {
 
 
 
-  // set up configurations ----------------------------------------------------
+  // set up configurations ====================================================
 
+  // --------------------------------------------------------------------------
+  //! Generate configuration for reconstructed jets
+  // --------------------------------------------------------------------------
   SEnergyCorrelatorConfig GetRecoConfig(
     const vector<string> cfg_inFiles,
     const string cfg_outFile,
@@ -136,7 +150,6 @@ namespace EnergyCorrelatorOptions {
       .isDebugOn     = doDebug,
       .isBatchOn     = cfg_doBatch,
       .isEmbed       = isEmbed,
-      .isLegacyInput = isLegacy,
       .isInTreeTruth = false,
       .moduleName    = "SRecoEnergyCorrelator",
       .inTreeName    = "RecoJetTree",
@@ -150,9 +163,9 @@ namespace EnergyCorrelatorOptions {
       .ptJetBins     = ptJetBins,
       .doManualCalc  = doManualCalc,
       .doThreePoint  = doThreePoint,
-      .RL_Bins       = RL_Bins,
-      .mom_option    = mom_option,
-      .norm_option   = norm_option,
+      .rlBins       = rlBins,
+      .momOption    = momOption,
+      .normOption   = normOption,
       .jetAccept     = GetJetAccept(),
       .cstAccept     = GetCstAccept()
     };
@@ -162,6 +175,9 @@ namespace EnergyCorrelatorOptions {
 
 
 
+  // --------------------------------------------------------------------------
+  //! Generate configuration for truth jets
+  // --------------------------------------------------------------------------
   SEnergyCorrelatorConfig GetTruthConfig(
     const vector<string> cfg_inFiles,
     const string cfg_outFile,
@@ -174,7 +190,6 @@ namespace EnergyCorrelatorOptions {
       .isDebugOn     = doDebug,
       .isBatchOn     = cfg_doBatch,
       .isEmbed       = isEmbed,
-      .isLegacyInput = isLegacy,
       .isInTreeTruth = true,
       .moduleName    = "TrueEnergyCorrelator",
       .inTreeName    = "TruthJetTree",
@@ -188,17 +203,17 @@ namespace EnergyCorrelatorOptions {
       .ptJetBins     = ptJetBins,
       .doManualCalc  = doManualCalc,
       .doThreePoint  = doThreePoint,
-      .RL_Bins       = RL_Bins,
-      .mom_option    = mom_option,
-      .norm_option   = norm_option,
+      .rlBins        = rlBins,
+      .momOption     = momOption,
+      .normOption    = normOption,
       .jetAccept     = GetJetAccept(),
       .cstAccept     = GetCstAccept(),
       .modCsts       = modCsts,
       .theta         = theta,
       .effVal        = effVal,
-      .pTSmear       = pTSmear,
+      .ptCstSmear    = ptCstSmear,
       .modJets       = modJets,
-      .jetPtSmear    = jetPtSmear
+      .ptJetSmear    = ptJetSmear
     };
     return cfg_true;
 

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -40,7 +40,7 @@ namespace EnergyCorrelatorOptions {
   const int  subEvtOpt = Const::SubEvtOpt::Everything;
   const bool isEmbed   = false;
   const bool doCstCuts = true;
-  const bool doDebug   = false;
+  const bool doDebug   = true;
   const bool doBatch   = false;
 
   // manual calculation option
@@ -86,6 +86,7 @@ namespace EnergyCorrelatorOptions {
   // acceptance cuts ==========================================================
 
   // jet acceptance
+  const pair<float, float> eneJetRange = {0.1,  100.};
   const pair<float, float> etaJetRange = {-0.7, 0.7};
 
   // cst acceptance
@@ -126,8 +127,10 @@ namespace EnergyCorrelatorOptions {
 
     // set specific bounds
     jetAccept.first.SetPT( ptJetBins.front().first );
+    jetAccept.first.SetEne( eneJetRange.first );
     jetAccept.first.SetEta( etaJetRange.first );
     jetAccept.second.SetPT( ptJetBins.back().second );
+    jetAccept.second.SetEne( eneJetRange.second );
     jetAccept.second.SetEta( etaJetRange.second );
     return jetAccept;
 

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -36,8 +36,8 @@ namespace EnergyCorrelatorOptions {
 
   // jet pT bins
   const vector<pair<double, double>> ptJetBins = {
-    {0., 5.},
-    {5., 10.},
+    {0.,  5.},
+    {5.,  10.},
     {10., 15.},
     {15., 20.},
     {20., 30.},
@@ -61,20 +61,26 @@ namespace EnergyCorrelatorOptions {
   const pair<float, float> drCstRange  = {0.,  100.};
   const pair<float, float> eneCstRange = {0.1, 100.};
 
-  // Smearing options
-  const bool modCsts = true;
-  const float theta = 0;
-  const float pTSmear = 0.02;
-  const float effVal = 1;
-  const bool modJets = true;
+  // smearing options
+  const bool  modCsts    = true;
+  const bool  modJets    = true;
+  const float theta      = 0;
+  const float pTSmear    = 0.02;
+  const float effVal     = 1;
   const float jetPtSmear = 0.02;
 
-  //Manual calculation option
+  // manual calculation option
   const bool doManualCalc = true;
   const bool doThreePoint = true;
-  const vector <pair<double, double>> RL_Bins = {{0.0, 0.22664}, {0.22664, 0.26666}, {0.26666, 1.0}};
-  const int mom_option = 0;
-  const int norm_option = 0;
+  const int  mom_option   = 0;
+  const int  norm_option  = 0;
+
+  // rl bins for for manual E3C calc
+  const vector<pair<double, double>> RL_Bins = {
+    {0.0,     0.22664},
+    {0.22664, 0.26666},
+    {0.26666, 1.0}
+  };
   
   // bundle acceptances into pairs --------------------------------------------
 
@@ -142,11 +148,11 @@ namespace EnergyCorrelatorOptions {
       .nBinsDr       = nBinsDr,
       .drBinRange    = binRangeDr,
       .ptJetBins     = ptJetBins,
-      .doManualCalc = doManualCalc,
-      .doThreePoint = doThreePoint,
-      .RL_Bins = RL_Bins,
-      .mom_option = mom_option,
-      .norm_option = norm_option,
+      .doManualCalc  = doManualCalc,
+      .doThreePoint  = doThreePoint,
+      .RL_Bins       = RL_Bins,
+      .mom_option    = mom_option,
+      .norm_option   = norm_option,
       .jetAccept     = GetJetAccept(),
       .cstAccept     = GetCstAccept()
     };
@@ -180,19 +186,19 @@ namespace EnergyCorrelatorOptions {
       .nBinsDr       = nBinsDr,
       .drBinRange    = binRangeDr,
       .ptJetBins     = ptJetBins,
-      .doManualCalc = doManualCalc,
-      .doThreePoint = doThreePoint,
-      .RL_Bins = RL_Bins,
-      .mom_option = mom_option,
-      .norm_option = norm_option,
+      .doManualCalc  = doManualCalc,
+      .doThreePoint  = doThreePoint,
+      .RL_Bins       = RL_Bins,
+      .mom_option    = mom_option,
+      .norm_option   = norm_option,
       .jetAccept     = GetJetAccept(),
       .cstAccept     = GetCstAccept(),
-      .modCsts = modCsts,
-      .theta = theta,
-      .effVal = effVal,
-      .pTSmear = pTSmear,
-      .modJets = modJets,
-      .jetPtSmear = jetPtSmear
+      .modCsts       = modCsts,
+      .theta         = theta,
+      .effVal        = effVal,
+      .pTSmear       = pTSmear,
+      .modJets       = modJets,
+      .jetPtSmear    = jetPtSmear
     };
     return cfg_true;
 

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -119,7 +119,8 @@ namespace EnergyCorrelatorOptions {
 
   }  // end 'MakeEffFunction()'
 
-  
+ 
+ 
   // bundle acceptances into pairs ============================================
 
   // --------------------------------------------------------------------------

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -44,10 +44,19 @@ namespace EnergyCorrelatorOptions {
   const bool doBatch   = false;
 
   // manual calculation option
+  const int  momOption    = 0;
+  const int  normOption   = 0;
   const bool doManualCalc = false;
   const bool doThreePoint = false;
-  const int  momOption   = 0;
-  const int  normOption  = 0;
+
+  // smearing options
+  //   - FIXME theta should be thetaSmear
+  const bool  modCsts    = true;
+  const bool  modJets    = true;
+  const float effVal     = 1;
+  const float theta      = 0;
+  const float ptCstSmear = 0.02;
+  const float ptJetSmear = 0.02;
 
   // jet pT bins
   const vector<pair<double, double>> ptJetBins = {
@@ -66,14 +75,6 @@ namespace EnergyCorrelatorOptions {
     {0.22664, 0.26666},
     {0.26666, 1.0}
   };
-
-  // smearing options
-  const bool  modCsts    = true;
-  const bool  modJets    = true;
-  const float theta      = 0;
-  const float ptCstSmear    = 0.02;
-  const float effVal     = 1;
-  const float ptJetSmear = 0.02;
 
   // acceptance cuts ==========================================================
 
@@ -163,9 +164,9 @@ namespace EnergyCorrelatorOptions {
       .ptJetBins     = ptJetBins,
       .doManualCalc  = doManualCalc,
       .doThreePoint  = doThreePoint,
-      .rlBins       = rlBins,
-      .momOption    = momOption,
-      .normOption   = normOption,
+      .rlBins        = rlBins,
+      .momOption     = momOption,
+      .normOption    = normOption,
       .jetAccept     = GetJetAccept(),
       .cstAccept     = GetCstAccept()
     };

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -40,30 +40,30 @@ namespace EnergyCorrelatorOptions {
   const int  subEvtOpt = Const::SubEvtOpt::Everything;
   const bool isEmbed   = false;
   const bool doCstCuts = true;
-  const bool doDebug   = true;
+  const bool doDebug   = false;
   const bool doBatch   = false;
 
   // calculation options
   const int  momOption     = 0;
   const int  normOption    = 0;
-  const bool doLocalCalc   = true;
+  const bool doLocalCalc   = false;
   const bool doGlobalCalc  = true;
   const bool doManualCalc  = false;
-  const bool doPackageCalc = true;
+  const bool doPackageCalc = false;
   const bool doThreePoint  = false;
 
   // smearing options
-  const bool   doJetSmear      = true;
-  const bool   doCstSmear      = true;
-  const bool   doCstPtSmear    = true;
-  const bool   doCstThetaSmear = true;
-  const bool   doCstPhiSmear   = true;
+  const bool   doJetSmear      = false;
+  const bool   doCstSmear      = false;
+  const bool   doCstPtSmear    = false;
+  const bool   doCstThetaSmear = false;
+  const bool   doCstPhiSmear   = false;
   const float  ptJetSmear      = 0.5;
   const float  ptCstSmear      = 0.1;
   const float  thCstSmear      = 0.01;
 
   // efficiency options
-  const bool   doCstEff    = true;
+  const bool   doCstEff    = false;
   const float  effValue    = 0.9;
   const float  effSmooth   = 4.0;
   const string effFunction = "[0]*(1.0-TMath::Exp(-1.0*[1]*x))";
@@ -94,7 +94,7 @@ namespace EnergyCorrelatorOptions {
   // acceptance cuts ==========================================================
 
   // jet acceptance
-  const pair<float, float> eneJetRange = {0.1,  100.};
+  const pair<float, float> eneJetRange = {0.2,  100.};
   const pair<float, float> etaJetRange = {-0.7, 0.7};
 
   // cst acceptance

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -50,14 +50,14 @@ namespace EnergyCorrelatorOptions {
   const bool doThreePoint = false;
 
   // smearing options
-  //   - FIXME theta should be thSmear
-  //   - FIXME modJets should be doJetSmear
-  //   - FIXME modCsts should be doCstSmear
-  const bool   modJets    = true;
-  const bool   modCsts    = true;
-  const float  theta      = 0;
-  const float  ptCstSmear = 0.02;
-  const float  ptJetSmear = 0.02;
+  const bool   doJetSmear      = true;
+  const bool   doCstSmear      = true;
+  const bool   doCstPtSmear    = true;
+  const bool   doCstThetaSmear = true;
+  const bool   doCstPhiSmear   = true;
+  const float  ptJetSmear      = 0.5;
+  const float  ptCstSmear      = 0.1;
+  const float  thCstSmear      = 0.01;
 
   // efficiency options
   const bool   doCstEff    = true;
@@ -210,36 +210,38 @@ namespace EnergyCorrelatorOptions {
   ) {
 
     SEnergyCorrelatorConfig cfg_true {
-      .verbosity     = cfg_verbosity,
-      .isDebugOn     = doDebug,
-      .isBatchOn     = cfg_doBatch,
-      .isEmbed       = isEmbed,
-      .isInTreeTruth = true,
-      .moduleName    = "TrueEnergyCorrelator",
-      .inTreeName    = "TruthJetTree",
-      .outFileName   = cfg_outFile,
-      .applyCstCuts  = doCstCuts,
-      .subEvtOpt     = subEvtOpt,
-      .inFileNames   = cfg_inFiles,
-      .nPoints       = nPoints,
-      .nBinsDr       = nBinsDr,
-      .drBinRange    = binRangeDr,
-      .ptJetBins     = ptJetBins,
-      .doManualCalc  = doManualCalc,
-      .doThreePoint  = doThreePoint,
-      .rlBins        = rlBins,
-      .momOption     = momOption,
-      .normOption    = normOption,
-      .jetAccept     = GetJetAccept(),
-      .cstAccept     = GetCstAccept(),
-      .modJets       = modJets,
-      .modCsts       = modCsts,
-      .doCstEff      = doCstEff
-      .theta         = theta,
-      .ptCstSmear    = ptCstSmear,
-      .modJets       = modJets,
-      .ptJetSmear    = ptJetSmear,
-      .funcEff       = MakeEffFunction()
+      .verbosity       = cfg_verbosity,
+      .isDebugOn       = doDebug,
+      .isBatchOn       = cfg_doBatch,
+      .isEmbed         = isEmbed,
+      .isInTreeTruth   = true,
+      .moduleName      = "TrueEnergyCorrelator",
+      .inTreeName      = "TruthJetTree",
+      .outFileName     = cfg_outFile,
+      .applyCstCuts    = doCstCuts,
+      .subEvtOpt       = subEvtOpt,
+      .inFileNames     = cfg_inFiles,
+      .nPoints         = nPoints,
+      .nBinsDr         = nBinsDr,
+      .drBinRange      = binRangeDr,
+      .ptJetBins       = ptJetBins,
+      .doManualCalc    = doManualCalc,
+      .doThreePoint    = doThreePoint,
+      .rlBins          = rlBins,
+      .momOption       = momOption,
+      .normOption      = normOption,
+      .jetAccept       = GetJetAccept(),
+      .cstAccept       = GetCstAccept(),
+      .doJetSmear      = doJetSmear,
+      .doCstSmear      = doCstSmear,
+      .doCstPtSmear    = doCstPtSmear,
+      .doCstThetaSmear = doCstThetaSmear,
+      .doCstPhiSmear   = doCstPhiSmear,
+      .doCstEff        = doCstEff,
+      .ptJetSmear      = ptJetSmear,
+      .ptCstSmear      = ptCstSmear,
+      .thCstSmear      = thCstSmear,
+      .funcEff         = MakeEffFunction()
     };
     return cfg_true;
 

--- a/EnergyCorrelatorOptions.h
+++ b/EnergyCorrelatorOptions.h
@@ -68,6 +68,11 @@ namespace EnergyCorrelatorOptions {
   const float  effSmooth   = 4.0;
   const string effFunction = "[0]*(1.0-TMath::Exp(-1.0*[1]*x))";
 
+  // event ht bins
+  const vector<pair<double, double>> htEvtBins = {
+    {0., 200.}
+  };
+
   // jet pT bins
   const vector<pair<double, double>> ptJetBins = {
     {0.,  5.},
@@ -191,6 +196,7 @@ namespace EnergyCorrelatorOptions {
       .nBinsDr       = nBinsDr,
       .drBinRange    = binRangeDr,
       .ptJetBins     = ptJetBins,
+      .htEvtBins     = htEvtBins,
       .doLocalCalc   = doLocalCalc,
       .doGlobalCalc  = doGlobalCalc,
       .doManualCalc  = doManualCalc,
@@ -234,6 +240,7 @@ namespace EnergyCorrelatorOptions {
       .nBinsDr         = nBinsDr,
       .drBinRange      = binRangeDr,
       .ptJetBins       = ptJetBins,
+      .htEvtBins       = htEvtBins,
       .doLocalCalc     = doLocalCalc,
       .doGlobalCalc    = doGlobalCalc,
       .doManualCalc    = doManualCalc,

--- a/README.md
+++ b/README.md
@@ -11,28 +11,17 @@ After copying the source files (located in `src/`), compile the module with the 
 ./sphx-build
 ```
 
-
-The macros `DoStandaloneCorrelatorCalculation.cxx` and `macros/Fun4All_DoStandaloneCalculation.C` illustrate how to use the module.  In the
-case of the former, the module is ran by itself in a ROOT macro.
+The macros `DoStandaloneCorrelatorCalculation.cxx` illustrate how to use the module.
 
 ```
-root -b -q DoStandaloneCorrelatorCalculation.cxx
+root -b -q RunENCCalculation.cxx
 ```
 
 All of the relevant parameters such as input/output files, n-points, jet pT bins, etc. are set in `EnergyCorrelatorOptions.h`  The script
-`DoStandaloneCorrelatorCalculation.rb` can be used to run this macro with fewer keystrokes.
-
-The latter macro illustrates how to run the module as an "afterburner" to Fun4All.  First, Fun4All runs the `SCorrelatorJetTreeMaker` module
-over the specified input files to produce the input jet trees for `SEnergyCorrelator`.  Then the module is run over the output from Fun4All. 
-This macro is run, like always, with:
-
-```
-root -b -q Fun4All_DoStandaloneCalculation.C
-```
+`RunENCCalculation.rb` can be used to run this macro with fewer keystrokes.
 
 ---
 
 ## To-Do:
 
 - [Major] Add functionality to run multiple n-points per calculation
-- [Minor] Update afterburner example macro

--- a/RunENCCalculation.cxx
+++ b/RunENCCalculation.cxx
@@ -38,8 +38,8 @@ void RunENCCalculation(const bool doBatch = false, const int verbosity = 0) {
     "../SCorrelatorJetTreeMaker/output/intermediate_merge/pp200py8jet10run15_towerSubAntiKtR04_2024sep28/correlatorJetTree.pp200py8jet10run15_towerSubAntiKtR04_0000to0099.d29m9y2024.root"
   };
   const pair<string, string> outFiles = {
-    "twoPoint.pp200py8jet10run15_antiKtTowerR04_packageCalcOnly.refactor_moveSmearToSeparateFunctions_reco.d21m10y2024.root",
-    "twoPoint.pp200py8jet10run15_antiKtTowerR04_packageCalcOnly.refactor_moveSmearTOSeparateFunctions_true.d21m10y2024.root"
+    "twoPoint.pp200py8jet10run15_antiKtTowerR04_packageCalcOnly.refactor_addGlobalCalc_reco.d6m11y2024.root",
+    "twoPoint.pp200py8jet10run15_antiKtTowerR04_packageCalcOnly.refactor_addGlobalCalc_true.d6m11y2024.root"
   };
 
   // get module configurations

--- a/RunENCCalculation.cxx
+++ b/RunENCCalculation.cxx
@@ -1,13 +1,14 @@
-// ----------------------------------------------------------------------------
-// 'DoStandaloneCorrelatorCalculation.cxx'
-// Derek Anderson
-// 02.02.2023
-//
-// Use this to run the SEnergyCorrelator class in standalone mode.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    RunENCCalculation.cxx
+ *  \authors Derek Anderson
+ *  \date    02.02.2023
+ *
+ *  A ROOT macro to run the SEnergyCorrelator module.
+ */
+/// ---------------------------------------------------------------------------
 
-#ifndef DOSTANDALONECORRELATORCALCULATION_CXX
-#define DOSTANDALONECORRELATORCALCULATION_CXX
+#ifndef RUNENCCALCULATION_CXX
+#define RUNENCCALCULATION_CXX
 
 // c++ utilities
 #include <string>
@@ -30,11 +31,11 @@ R__LOAD_LIBRARY(libscorrelatorutilities.so)
 
 // macro body -----------------------------------------------------------------
 
-void DoStandaloneCorrelatorCalculation(const bool doBatch = false, const int verbosity = 0) {
+void RunENCCalculation(const bool doBatch = false, const int verbosity = 0) {
 
   // input/output files
   const vector<string> inFiles = {
-    "../SCorrelatorJetTreeMaker/output/condor/final_merge/correlatorJetTree.pp200py8jet10run8_trksWithRoughCuts.d26m9y2023.root"
+    "../SCorrelatorJetTreeMaker/output/intermediate_merge/pp200py8jet10run15_towerSubAntiKtR04_2024sep28/correlatorJetTree.pp200py8jet10run15_towerSubAntiKtR04_0000to0099.d29m9y2024.root"
   };
   const pair<string, string> outFiles = {
     "twoPoint.pp200py8jet10run8.refactor_cleanUpCutFunctions_reco.d19m3y2024.root",

--- a/RunENCCalculation.cxx
+++ b/RunENCCalculation.cxx
@@ -47,12 +47,10 @@ void RunENCCalculation(const bool doBatch = false, const int verbosity = 0) {
   SEnergyCorrelatorConfig cfg_true = EnergyCorrelatorOptions::GetTruthConfig(inFiles, outFiles.second, doBatch, verbosity);
 
   // do correlator calculation on reco jets
-/* TEST
   SEnergyCorrelator* recoCorrelator = new SEnergyCorrelator(cfg_reco);
   recoCorrelator -> Init();
   recoCorrelator -> Analyze();
   recoCorrelator -> End();
-*/
 
   // do correlator calculation on truth jets
   SEnergyCorrelator* trueCorrelator = new SEnergyCorrelator(cfg_true);

--- a/RunENCCalculation.cxx
+++ b/RunENCCalculation.cxx
@@ -38,8 +38,8 @@ void RunENCCalculation(const bool doBatch = false, const int verbosity = 0) {
     "../SCorrelatorJetTreeMaker/output/intermediate_merge/pp200py8jet10run15_towerSubAntiKtR04_2024sep28/correlatorJetTree.pp200py8jet10run15_towerSubAntiKtR04_0000to0099.d29m9y2024.root"
   };
   const pair<string, string> outFiles = {
-    "twoPoint.pp200py8jet10run8.refactor_cleanUpCutFunctions_reco.d19m3y2024.root",
-    "twoPoint.pp200py8jet10run8.refactor_cleanUpCutFunctions_true.d19m3y2024.root"
+    "twoPoint.pp200py8jet10run15_antiKtTowerR04_packageCalcOnly.refactor_moveSmearToSeparateFunctions_reco.d21m10y2024.root",
+    "twoPoint.pp200py8jet10run15_antiKtTowerR04_packageCalcOnly.refactor_moveSmearTOSeparateFunctions_true.d21m10y2024.root"
   };
 
   // get module configurations
@@ -47,10 +47,12 @@ void RunENCCalculation(const bool doBatch = false, const int verbosity = 0) {
   SEnergyCorrelatorConfig cfg_true = EnergyCorrelatorOptions::GetTruthConfig(inFiles, outFiles.second, doBatch, verbosity);
 
   // do correlator calculation on reco jets
+/* TEST
   SEnergyCorrelator* recoCorrelator = new SEnergyCorrelator(cfg_reco);
   recoCorrelator -> Init();
   recoCorrelator -> Analyze();
   recoCorrelator -> End();
+*/
 
   // do correlator calculation on truth jets
   SEnergyCorrelator* trueCorrelator = new SEnergyCorrelator(cfg_true);

--- a/RunENCCalculation.rb
+++ b/RunENCCalculation.rb
@@ -1,16 +1,16 @@
 #!/usr/bin/env ruby
 # -----------------------------------------------------------------------------
-# 'DoStandaloneCorrelatorCalculation.rb'
-# Derek Anderson
-# 01.18.2024
+# \file   RunENCCalculation.rb
+# \author Derek Anderson
+# \date   01.18.2024
 #
-# Short script to run the 'DoStandaloneCorrelatorCalculation.C' macro.
+# Short script to run RunENCCalculation.cxx
 # -----------------------------------------------------------------------------
 
 if ARGV[0] == "condor"
-  exec("condor_submit DoStandaloneCorrelatorCalculationOnCondor.job")
+  exec("condor_submit RunENCCalculationOnCondor.job")
 else
-  exec("root -b -q DoStandaloneCorrelatorCalculation.cxx")
+  exec("root -b -q RunENCCalculation.cxx")
 end
 
 # end -------------------------------------------------------------------------

--- a/RunENCCalculationOnCondor.job
+++ b/RunENCCalculationOnCondor.job
@@ -1,9 +1,9 @@
 # -----------------------------------------------------------------------------
-# 'RunStandaloneCorrelatorCalculationOnCondor.job'
-# Derek Anderson
-# 03.20.2024
+# \file   RunENCCalculationOnCondor.job
+# \author Derek Anderson
+# \date   03.20.2024
 #
-# Job file to run standalone correlator calculations via condor.
+# Job file to run RunENCCalculation.cxx on condor.
 # -----------------------------------------------------------------------------
 
 # generic parameters
@@ -11,10 +11,10 @@ Universe     = vanilla
 notification = Never
 
 # executable parameters
-Executable           = DoStandaloneCorrelatorCalculationOnCondor.sh
+Executable           = RunENCCalculationOnCondor.sh
 Initialdir           = ./
 request_memory       = 8GB
-transfer_input_files = DoStandaloneCorrelatorCalculation.cxx,EnergyCorrelatorOptions.h
+transfer_input_files = RunENCCalculation.cxx,EnergyCorrelatorOptions.h
 
 # output parameters
 Output = /sphenix/user/danderson/eec/SEnergyCorrelator/log/testCalc.out

--- a/RunENCCalculationOnCondor.sh
+++ b/RunENCCalculationOnCondor.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # -----------------------------------------------------------------------------
-# 'DoStandaloneCorrelatorCalculationOnCondor.sh'
-# Derek Anderson
-# 03.20.2024
+# \file   RunENCCalculationOnCondor.sh
+# \author Derek Anderson
+# \date   03.20.2024
 #
 # short script to run DoStandaloneCorrelatorCalculation.cxx via condor
 # -----------------------------------------------------------------------------
@@ -11,10 +11,18 @@
 export USER="$(id -u -n)"
 export LOGNAME=${USER}
 export HOME=/sphenix/u/${LOGNAME}
+export MYINSTALL=/sphenix/u/danderson/install
 source /opt/sphenix/core/bin/sphenix_setup.sh
 printenv
 
+# add install path to LD_LIBRARY_PATH
+echo $MYINSTALL
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MYINSTALL/lib
+
+# print library path for debugging
+echo $LD_LIBRARY_PATH
+
 # run macro
-root -b -q "DoStandaloneCorrelatorCalculation.cxx(true)"
+root -b -q "RunENCCalculation.cxx(true)"
 
 # end -------------------------------------------------------------------------

--- a/scripts/copy-to-analysis.rb
+++ b/scripts/copy-to-analysis.rb
@@ -18,10 +18,10 @@ copy_to   = "/sphenix/user/danderson/sphenix/analysis/AndersonAnalysisModules/Co
 # what files to copy
 to_copy = [
   "README.md",
-  "DoStandaloneCorrelatorCalculation.cxx",
-  "DoStandaloneCorrelatorCalculation.rb",
-  "DoStandaloneCorrelatorCalculationOnCondor.sh",
-  "DoStandaloneCorrelatorCalculationOnCondor.job",
+  "RunENCCalculation.cxx",
+  "RunENCCalculation.rb",
+  "RunENCCalculationOnCondor.sh",
+  "RunENCCalculationOnCondor.job",
   "EnergyCorrelatorOptions.h",
   "scripts/copy-to-analysis.rb",
   "scripts/wipe-source.sh",

--- a/scripts/copy-to-analysis.rb
+++ b/scripts/copy-to-analysis.rb
@@ -13,7 +13,7 @@ require 'fileutils'
 
 # top directory to copy from/to
 copy_from = "/sphenix/user/danderson/eec/SEnergyCorrelator"
-copy_to   = "/sphenix/user/danderson/sphenix/analysis/AndersonAnalysisModules/ColdQcdCorrelatorAnalysis/SEnergyCorrelator"
+copy_to   = "/sphenix/user/danderson/sphenix/analysis/EnergyCorrelatorsJets/ColdQCDENC/SEnergyCorrelator"
 
 # what files to copy
 to_copy = [

--- a/src/SEnergyCorrelator.ana.h
+++ b/src/SEnergyCorrelator.ana.h
@@ -217,9 +217,10 @@ namespace SColdQcdCorrelatorAnalysis {
         /* FIXME in prepping for multiple n per calc..
          *   - should make nPoints a set
          *   - might want to move this to a separate function...
-         *   - also can remove the 3 point flag
+         *   - also can remove the 3 point flag at that point, e.g.
+         *       if (!m_config.nPoints.count(3)) continue;
          */  
-        if ((m_config.nPoints.count(3) == 0) || !m_config.doThreePoint) continue;
+        if (!m_config.doThreePoint) continue;
 
         // 3rd cst loop
         for (uint64_t kCst = 0; kCst < m_cstCalcVec.size(); kCst++) {
@@ -296,7 +297,7 @@ namespace SColdQcdCorrelatorAnalysis {
               const bool isInRLBin = (
                 (RL >= m_config.rlBins[jRLBin].first) &&
                 (RL < m_config.rlBins[jRLBin].second)
-              )
+              );
               if (!isInRLBin) continue;
 
               // fill hist
@@ -576,7 +577,7 @@ namespace SColdQcdCorrelatorAnalysis {
 
     // calculate Et wrt reference if provided,
     // othwerwise use built-in value
-    double et = momenutm.Et();
+    double et = momentum.Et();
     if (reference.has_value()) {
       et = GetET(
         TVector3(
@@ -596,7 +597,7 @@ namespace SColdQcdCorrelatorAnalysis {
     double weight = 1.;
     switch (option) {
       case Norm::Et:
-        weight = Et;
+        weight = et;
         break;
       case Norm::E:
         weight = momentum.E();
@@ -617,7 +618,7 @@ namespace SColdQcdCorrelatorAnalysis {
   //! Get median distance from a triplet
   // --------------------------------------------------------------------------
   /* FIXME can probably replace this w/ clever use of some stl containers */
-  double GetRM(const tuple<double, double, double>& dists) {
+  double SEnergyCorrelator::GetRM(const tuple<double, double, double>& dists) {
 
     // print debug statement
     //   - FIXME give proper code
@@ -650,14 +651,14 @@ namespace SColdQcdCorrelatorAnalysis {
     // by default return 1st element
     return get<0>(dists);
 
-  }  // end 'GetRM(tuple<double, double, double>)'
+  }  // end 'GetRM(tuple<double, double, double>&)'
 
 
 
   // --------------------------------------------------------------------------
   //! Get energy transverse to a provided reference
   // --------------------------------------------------------------------------
-  double GetET(const TVector3& pMom, const TVector3& pRef) {
+  double SEnergyCorrelator::GetET(const TVector3& pMom, const TVector3& pRef) {
 
     // print debug statement
     // FIXME provide an actual code

--- a/src/SEnergyCorrelator.ana.h
+++ b/src/SEnergyCorrelator.ana.h
@@ -47,7 +47,7 @@ namespace SColdQcdCorrelatorAnalysis {
         m_input.jets[iJet].GetPhi(),
         m_input.jets[iJet].GetEne()
       );
-      if (m_config.doJetSmear) SmearJetMomentum(pJetVector);
+      if (m_config.isInTreeTruth && m_config.doJetSmear) SmearJetMomentum(pJetVector);
 
       // constituent loop
       for (uint64_t iCst = 0; iCst < m_input.csts[iJet].size(); iCst++) {
@@ -57,17 +57,17 @@ namespace SColdQcdCorrelatorAnalysis {
         if (!isGoodCst) continue;
 
         // create cst 4-vector, smear if need be
-        PtEtaPhiMVector pCstVector(
+        PtEtaPhiEVector pCstVector(
           m_input.csts[iJet][iCst].GetPT(),
           m_input.csts[iJet][iCst].GetEta(),
           m_input.csts[iJet][iCst].GetPhi(),
-          Const::MassPion()
+          m_input.csts[iJet][iCst].GetEne()
         );
-        if (m_config.doCstSmear) SmearCstMomentum(pCstVector);
+        if (m_config.isInTreeTruth && m_config.doCstSmear) SmearCstMomentum(pCstVector);
 
         // apply efficiency if need be
         if (m_config.doCstEff) {
-          bool surives = SurvivesEfficiency(pCstVector.Pt());
+          bool survives = SurvivesEfficiency(pCstVector.Pt());
           if (!survives) continue;
         }
 
@@ -474,7 +474,6 @@ namespace SColdQcdCorrelatorAnalysis {
 
     // grab unsmeared jet pt, E & calculate mass
     const double ptOrig = pJet.Pt();
-    const double eOrig  = pJet.E();
     const double mJet   = pJet.M();
 
     // apply smearing
@@ -525,11 +524,12 @@ namespace SColdQcdCorrelatorAnalysis {
     }
 
     // update 4-vector and exit
+    const double eSmear = hypot( pSmearVec3.Mag(), Const::MassPion() );
     if (m_config.doCstThetaSmear || m_config.doCstPhiSmear) {
       pCst.SetPt( pSmearVec3.Pt() );
       pCst.SetEta( pSmearVec3.Eta() );
       pCst.SetPhi( pSmearVec3.Phi() );
-      pCst.SetE( pSmearVec3.E() );
+      pCst.SetE( eSmear );
     }
     return;
 

--- a/src/SEnergyCorrelator.ana.h
+++ b/src/SEnergyCorrelator.ana.h
@@ -27,7 +27,6 @@ namespace SColdQcdCorrelatorAnalysis {
   void SEnergyCorrelator::RunCalculations() {
 
     // print debug statement
-    // TODO update debug statement
     if (m_config.isDebugOn) PrintDebug(31);
 
     // helper lambda to turn a PtEtaPhiEVector into a PseudoJet
@@ -134,8 +133,7 @@ namespace SColdQcdCorrelatorAnalysis {
   void SEnergyCorrelator::DoGlobalCalcManual(const double normGlobal) {
     
     // print debug statement
-    // TODO give it an actual debug message
-    if (m_config.isDebugOn) PrintDebug(777);
+    if (m_config.isDebugOn) PrintDebug(38);
 
     /* TODO fill in */
     return;
@@ -151,6 +149,7 @@ namespace SColdQcdCorrelatorAnalysis {
 
     // print debug statement
     if (m_config.isDebugOn) PrintDebug(31);
+
     const int32_t iPtJetBin = GetJetPtBin( ptJet );
     const bool    foundBin  = (iPtJetBin >= 0);
     const bool    hasCsts   = (m_cstCalcVec.size() > 0); 
@@ -167,6 +166,9 @@ namespace SColdQcdCorrelatorAnalysis {
   //! Run local (in-jet) calculations manually
   // --------------------------------------------------------------------------
   void SEnergyCorrelator::DoLocalCalcManual(const PtEtaPhiEVector& normalization) {
+
+    // print debug statement
+    if (m_config.isDebugOn) PrintDebug(39);
 
     // get normalization for weights
     double norm = GetWeight(normalization, m_config.normOption);
@@ -585,6 +587,9 @@ namespace SColdQcdCorrelatorAnalysis {
     optional<PtEtaPhiEVector> reference
   ) {
 
+    // print debug statement
+    if (m_config.isDebugOn && (m_config.verbosity > 7)) PrintDebug(40);
+
     // calculate Et wrt reference if provided,
     // othwerwise use built-in value
     //   - FIXME might be good to swap out the TVector3
@@ -633,8 +638,7 @@ namespace SColdQcdCorrelatorAnalysis {
   double SEnergyCorrelator::GetRM(const tuple<double, double, double>& dists) {
 
     // print debug statement
-    //   - FIXME give proper code
-    if (m_config.isDebugOn && (m_config.verbosity > 7)) PrintDebug(777);
+    if (m_config.isDebugOn && (m_config.verbosity > 7)) PrintDebug(41);
   
     // check if first element is median
     if (
@@ -670,11 +674,11 @@ namespace SColdQcdCorrelatorAnalysis {
   // --------------------------------------------------------------------------
   //! Get energy transverse to a provided reference
   // --------------------------------------------------------------------------
+  /* FIXME might be good to swap out the TVector3 for PtEtaPhiEVector */
   double SEnergyCorrelator::GetET(const TVector3& pMom, const TVector3& pRef) {
 
     // print debug statement
-    // FIXME provide an actual code
-    if (m_config.isDebugOn && (m_config.verbosity > 7)) PrintDebug(777);
+    if (m_config.isDebugOn && (m_config.verbosity > 7)) PrintDebug(42);
 
     // get component transverse to reference
     TVector3 pProduct    = ((pMom * pRef) / (pRef * pRef)) * pRef;

--- a/src/SEnergyCorrelator.ana.h
+++ b/src/SEnergyCorrelator.ana.h
@@ -24,7 +24,6 @@ namespace SColdQcdCorrelatorAnalysis {
   // --------------------------------------------------------------------------
   //! Run local (in-jet) ENC calculations
   // --------------------------------------------------------------------------
-  /*! FIXME move smearing to a seperate function */
   void SEnergyCorrelator::DoLocalCalculation() {
     
     // print debug statement
@@ -106,11 +105,11 @@ namespace SColdQcdCorrelatorAnalysis {
 
     // print debug statement
     if (m_config.isDebugOn) PrintDebug(31);
-    const uint32_t iPtJetBin = GetJetPtBin( ptJet );
-    const bool     foundBin  = (iPtJetBin >= 0);
-    const bool     hasCsts   = (m_jetCstVector.size() > 0); 
+    const int32_t iPtJetBin = GetJetPtBin( ptJet );
+    const bool    foundBin  = (iPtJetBin >= 0);
+    const bool    hasCsts   = (m_jetCstVector.size() > 0); 
     if (foundBin && hasCsts) {
-      m_eecLongSide[iPtJetBin] -> compute(m_jetCstVector);
+      m_eecLongSide.at(iPtJetBin) -> compute(m_jetCstVector);
     }
     return;
 
@@ -449,8 +448,8 @@ namespace SColdQcdCorrelatorAnalysis {
     // print debug statement
     if (m_config.isDebugOn && (m_config.verbosity > 7)) PrintDebug(28);
  
-    bool    isInPtBin(false);
-    int32_t iJetPtBin(-1);
+    bool    isInPtBin = false;
+    int32_t iJetPtBin = -1;
     for (size_t iPtBin = 0; iPtBin < m_config.ptJetBins.size(); iPtBin++) {
       isInPtBin = ((ptJet >= m_config.ptJetBins[iPtBin].first) && (ptJet < m_config.ptJetBins[iPtBin].second));
       if (isInPtBin) {

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -34,6 +34,9 @@ namespace SColdQcdCorrelatorAnalysis {
     SubsysReco(config.moduleName)
   {
 
+    // print debug statement
+    if (config.isDebugOn) PrintDebug(44);
+
     // set config & initialize internal variables
     m_config = config;
     InitializeMembers();

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -102,7 +102,7 @@ namespace SColdQcdCorrelatorAnalysis {
     PrintMessage(1);
 
     // initialize smearing if need be
-    if (m_config.isTreeTruth && m_config.modJets) {
+    if (m_config.isInTreeTruth && (m_config.doJetSmear || m_config.doCstSmear)) {
       InitializeSmearing();
     }
 

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -1,12 +1,12 @@
-// ----------------------------------------------------------------------------
-// 'SEnergyCorrelator.cc'
-// Derek Anderson
-// 01.20.2023
-//
-// A module to implement Peter Komiske's EEC library
-// in the sPHENIX software stack for the Cold QCD
-// Energy-Energy Correlator analysis.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    SEnergyCorrelator.cc
+ *  \authors Derek Anderson, Alex Clarke
+ *  \date    01.20.2023
+ *
+ *  A module to run ENC calculations in the sPHENIX
+ *  software stack for the Cold QCD EEC analysis.
+ */
+/// ---------------------------------------------------------------------------
 
 #define SENERGYCORRELATOR_CC
 
@@ -25,21 +25,29 @@ using namespace findNode;
 
 namespace SColdQcdCorrelatorAnalysis {
 
-  // ctor/dtor ----------------------------------------------------------------
+  // ctor/dtor =================================================================
 
-  SEnergyCorrelator::SEnergyCorrelator(SEnergyCorrelatorConfig& config) : SubsysReco(config.moduleName) {
+  // --------------------------------------------------------------------------
+  //! Module ctor accepting config struct
+  // --------------------------------------------------------------------------
+  SEnergyCorrelator::SEnergyCorrelator(SEnergyCorrelatorConfig& config) :
+    SubsysReco(config.moduleName)
+  {
 
     // set config & initialize internal variables
     m_config = config;
     InitializeMembers();
 
     // announce start of calculation
-    if (m_config.isStandalone) PrintMessage(0);
+    PrintMessage(0);
 
   }  // end ctor(SEnergyCorrelatorConfig&)
 
 
 
+  // --------------------------------------------------------------------------
+  //! Module dtor
+  // --------------------------------------------------------------------------
   SEnergyCorrelator::~SEnergyCorrelator() {
 
     // print debug statement
@@ -59,7 +67,7 @@ namespace SColdQcdCorrelatorAnalysis {
       delete m_outPackageHistErrLnDrAxis.at(iPtBin);
       delete m_outManualHistErrDrAxis.at(iPtBin);
       delete m_outProjE3C.at(iPtBin);
-      for(size_t jRLBin = 0; jRLBin < m_config.RL_Bins.size(); jRLBin++){
+      for(size_t jRLBin = 0; jRLBin < m_config.rlBins.size(); jRLBin++){
 	delete m_outE3C[iPtBin].at(jRLBin);
       }
     }
@@ -76,20 +84,18 @@ namespace SColdQcdCorrelatorAnalysis {
 
 
 
-  // public methods -----------------------------------------------------------
+  // public methods ===========================================================
 
+  // --------------------------------------------------------------------------
+  //! Module initialization
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::Init() {
 
     // print debug statement
     if (m_config.isDebugOn) PrintDebug(10);
 
-    // make sure standalone mode is on & open files
-    if (m_config.isStandalone) {
-      OpenInputFiles();
-    } else {
-      PrintError(5);
-      assert(m_config.isStandalone);
-    }
+    // open input/output files
+    OpenInputFiles();
     OpenOutputFile();
 
     // announce files
@@ -101,20 +107,17 @@ namespace SColdQcdCorrelatorAnalysis {
     InitializeHists();
     return;
 
-  }  // end 'StandaloneInit()'
+  }  // end 'Init()'
 
 
 
+  // --------------------------------------------------------------------------
+  //! Run analysis
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::Analyze() {
 
     // print debug statement
     if (m_config.isDebugOn) PrintDebug(12);
-
-    // make sure standalone mode is on
-    if (!m_config.isStandalone) {
-      PrintError(8);
-      assert(m_config.isStandalone);
-    }
 
     // announce start of event loop
     const uint64_t nEvts = m_inChain -> GetEntriesFast();
@@ -135,10 +138,8 @@ namespace SColdQcdCorrelatorAnalysis {
         PrintMessage(8, nEvts, iEvt);
       }
 
-      // if using legacy input, fill container
-      if (m_config.isLegacyInput) {
-        m_legacy.SetCorrelatorInput(m_input, m_config.isInTreeTruth, m_config.isEmbed);
-      }
+      // fill container
+      m_interface.SetCorrelatorInput(m_input, m_config.isInTreeTruth, m_config.isEmbed);
  
       // run calculations
       DoLocalCalculation();
@@ -153,33 +154,25 @@ namespace SColdQcdCorrelatorAnalysis {
     PrintMessage(9);
     return;
 
-  }  // end 'StandaloneAnalyze()'
+  }  // end 'Analyze()'
 
 
 
+  // --------------------------------------------------------------------------
+  //! Module wind-down
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::End() {
 
     // print debug statement
     if (m_config.isDebugOn) PrintDebug(13);
 
-    // make sure standalone mode is on & save output
-    if (m_config.isStandalone) {
-      SaveOutput();
-    } else {
-      PrintError(9);
-      assert(m_config.isStandalone);
-    }
-
-    // close files and announce end
-    if (!m_config.isStandalone) {
-      PrintError(15);
-      assert(m_config.isStandalone);
-    }
+    // save output, close files, and exit
+    SaveOutput();
     CloseOutputFile();
     PrintMessage(11);
     return;
 
-  }  // end 'StandaloneEnd()'
+  }  // end 'End()'
 
 }  // end SColdQcdCorrelatorAnalysis namespace
 

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -143,11 +143,13 @@ namespace SColdQcdCorrelatorAnalysis {
         PrintMessage(8, nEvts, iEvt);
       }
 
-      // fill container
-      m_interface.SetCorrelatorInput(m_input, m_config.isInTreeTruth, m_config.isEmbed);
- 
-      // run calculations
-      DoLocalCalculation();
+      // fill container and run calculations
+      m_interface.SetCorrelatorInput(
+        m_input,
+        m_config.isInTreeTruth,
+        m_config.isEmbed
+      );
+      RunCalculations();
 
     }  // end event loop
 

--- a/src/SEnergyCorrelator.cc
+++ b/src/SEnergyCorrelator.cc
@@ -101,6 +101,11 @@ namespace SColdQcdCorrelatorAnalysis {
     // announce files
     PrintMessage(1);
 
+    // initialize smearing if need be
+    if (m_config.isTreeTruth && m_config.modJets) {
+      InitializeSmearing();
+    }
+
     // initialize input, output, & correlators
     InitializeTree();
     InitializeCorrs();

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -109,16 +109,17 @@ namespace SColdQcdCorrelatorAnalysis {
       void PrintError(const uint32_t code, const size_t nDrBinEdges = 0, const size_t iDrBin = 0, const string sInFileName = "");
 
       // analysis methods (*.ana.h)
-      void            DoLocalCalculation();
-      void            DoLocalCalcWithPackage(const double ptJet);
-      void            DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, PtEtaPhiEVector normalization);
-      void            ExtractHistsFromCorr();
-      bool            IsGoodJet(const Types::JetInfo& jet);
-      bool            IsGoodCst(const Types::CstInfo& cst);
-      double          GetWeight(PtEtaPhiEVector momentum, int option, optional<PtEtaPhiEVector> reference = nullopt);
-      int32_t         GetJetPtBin(const double ptJet);
-      PtEtaPhiEVector SmearJetMomentum(const Types::JetInfo& jet);
-      PtEtaPhiEVector SmearCstMomentum(const Types::CstInfo& cst);
+      void    DoLocalCalculation();
+      void    DoLocalCalcWithPackage(const double ptJet);
+      void    DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, PtEtaPhiEVector normalization);
+      void    ExtractHistsFromCorr();
+      void    SmearJetMomentum(PtEtaPhiEVector& pJet);
+      void    SmearCstMomentum(PtEtaPhiEVector& pCst);
+      bool    IsGoodJet(const Types::JetInfo& jet);
+      bool    IsGoodCst(const Types::CstInfo& cst);
+      bool    SurvivesEfficiency(const double value);
+      double  GetWeight(PtEtaPhiEVector momentum, int option, optional<PtEtaPhiEVector> reference = nullopt);
+      int32_t GetJetPtBin(const double ptJet);
 
       // configuration
       SEnergyCorrelatorConfig m_config;
@@ -128,7 +129,7 @@ namespace SColdQcdCorrelatorAnalysis {
       TFile*  m_inFile  = NULL;
       TChain* m_inChain = NULL;
 
-      // for smearing truth momenta
+      // smearing members
       TRandom2* m_rando  = NULL;
 
       // system members

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -114,8 +114,8 @@ namespace SColdQcdCorrelatorAnalysis {
       // analysis methods (*.ana.h)
       void    DoGlobalCalculation();  // TODO
       void    DoGlobalCalculationWithPackage(const double htEvt);  // TODO
-      void    DoGlobalCalculationManual();  // TODO
-      void    DoLocalCalculation(const PtEtaPhiEVector& normalization);
+      void    DoGlobalCalculationManual(const PtEtaPhiEVector& normalization);  // TODO
+      void    DoLocalCalculation();
       void    DoLocalCalcWithPackage(const double ptJet);
       void    DoLocalCalcManual(const PtEtaPhiEVector& normalization);
       void    ExtractHistsFromCorr();
@@ -125,8 +125,8 @@ namespace SColdQcdCorrelatorAnalysis {
       bool    IsGoodCst(const Types::CstInfo& cst);
       bool    SurvivesEfficiency(const double value);
       double  GetWeight(const PtEtaPhiEVector& momentum, const int option, optional<PtEtaPhiEVector> reference = nullopt);
-      double  GetRM(const tuple<double, double, double> dists);
-      double  GetET(const TVector3& pRef, const TVector3& pRef);
+      double  GetRM(const tuple<double, double, double>& dists);
+      double  GetET(const TVector3& pMom, const TVector3& pRef);
       int32_t GetJetPtBin(const double ptJet);
 
       // configuration

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -161,8 +161,9 @@ namespace SColdQcdCorrelatorAnalysis {
 
       // global output histograms
       //   - FIXME move these to a dedicated histogram manager
-      vector<TH1D*> m_outGlobalHistThetaAxis;
-      vector<TH1D*> m_outGlobalHistCosThAxis;
+      //   - FIXME also add pi-phi versions
+      vector<TH1D*> m_outGlobalHistDPhiAxis;
+      vector<TH1D*> m_outGlobalHistCosDFAxis;
 
       // correlators
       vector<fastjet::contrib::eec::EECLongestSide<fastjet::contrib::eec::hist::axis::log>*> m_eecLongSide;

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -12,6 +12,7 @@
 #define SENERGYCORRELATOR_H
 
 // c++ utilities
+#include <map>
 #include <set>
 #include <limits>
 #include <string>
@@ -145,15 +146,23 @@ namespace SColdQcdCorrelatorAnalysis {
       vector<fastjet::PseudoJet> m_jetCalcVec;
       vector<fastjet::PseudoJet> m_cstCalcVec;
 
-      // output histograms
-      //   - FIXME move these to a dedicate histogram manager
+      // local package output histograms
+      //   - FIXME move these to a dedicated histogram manager
       vector<TH1D*> m_outPackageHistVarDrAxis;
       vector<TH1D*> m_outPackageHistErrDrAxis;
       vector<TH1D*> m_outPackageHistVarLnDrAxis;
       vector<TH1D*> m_outPackageHistErrLnDrAxis;
-      vector<TH1D*> m_outManualHistErrDrAxis;
+
+      // local manual output histograms
+      //   - FIXME move these to a dedicated histogram manager
+      vector<TH1D*>         m_outManualHistErrDrAxis;
+      vector<TH1D*>         m_outProjE3C;
       vector<vector<TH2D*>> m_outE3C;
-      vector<TH1D*> m_outProjE3C;
+
+      // global output histograms
+      //   - FIXME move these to a dedicated histogram manager
+      vector<TH1D*> m_outGlobalHistThetaAxis;
+      vector<TH1D*> m_outGlobalHistCosThAxis;
 
       // correlators
       vector<fastjet::contrib::eec::EECLongestSide<fastjet::contrib::eec::hist::axis::log>*> m_eecLongSide;

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -12,6 +12,7 @@
 #define SENERGYCORRELATOR_H
 
 // c++ utilities
+#include <set>
 #include <limits>
 #include <string>
 #include <vector>
@@ -19,6 +20,7 @@
 #include <utility>
 #include <iostream>
 #include <optional>
+#include <algorithm>
 // root libraries
 #include <TF1.h>
 #include <TH1.h>
@@ -110,16 +112,21 @@ namespace SColdQcdCorrelatorAnalysis {
       void PrintError(const uint32_t code, const size_t nDrBinEdges = 0, const size_t iDrBin = 0, const string sInFileName = "");
 
       // analysis methods (*.ana.h)
-      void    DoLocalCalculation();
+      void    DoGlobalCalculation();  // TODO
+      void    DoGlobalCalculationWithPackage(const double htEvt);  // TODO
+      void    DoGlobalCalculationManual();  // TODO
+      void    DoLocalCalculation(const PtEtaPhiEVector& normalization);
       void    DoLocalCalcWithPackage(const double ptJet);
-      void    DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, PtEtaPhiEVector normalization);
+      void    DoLocalCalcManual(const PtEtaPhiEVector& normalization);
       void    ExtractHistsFromCorr();
       void    SmearJetMomentum(PtEtaPhiEVector& pJet);
       void    SmearCstMomentum(PtEtaPhiEVector& pCst);
       bool    IsGoodJet(const Types::JetInfo& jet);
       bool    IsGoodCst(const Types::CstInfo& cst);
       bool    SurvivesEfficiency(const double value);
-      double  GetWeight(PtEtaPhiEVector momentum, int option, optional<PtEtaPhiEVector> reference = nullopt);
+      double  GetWeight(const PtEtaPhiEVector& momentum, const int option, optional<PtEtaPhiEVector> reference = nullopt);
+      double  GetRM(const tuple<double, double, double> dists);
+      double  GetET(const TVector3& pRef, const TVector3& pRef);
       int32_t GetJetPtBin(const double ptJet);
 
       // configuration
@@ -137,7 +144,8 @@ namespace SColdQcdCorrelatorAnalysis {
       int m_fCurrent = 0;
 
       // for correlator calculations
-      vector<fastjet::PseudoJet> m_jetCstVector;
+      vector<fastjet::PseudoJet> m_jetCalcVec;
+      vector<fastjet::PseudoJet> m_cstCalcVec;
 
       // output histograms
       //   - FIXME move these to a dedicate histogram manager

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -20,10 +20,12 @@
 #include <iostream>
 #include <optional>
 // root libraries
+#include <TF1.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TFile.h>
 #include <TChain.h>
+#include <TDatime.h>
 #include <TString.h>
 #include <TRandom2.h>
 #include <TVector3.h>
@@ -53,7 +55,7 @@
 
 // make common namespaces implicit
 using namespace std;
-
+using namespace ROOT::Math;
 
 
 namespace SColdQcdCorrelatorAnalysis {
@@ -101,19 +103,22 @@ namespace SColdQcdCorrelatorAnalysis {
       void InitializeHists();
       void InitializeCorrs();
       void InitializeTree();
+      void InitializeSmearing();
       void PrintMessage(const uint32_t code, const uint64_t nEvts = 0, const uint64_t event = 0);
       void PrintDebug(const uint32_t code);
       void PrintError(const uint32_t code, const size_t nDrBinEdges = 0, const size_t iDrBin = 0, const string sInFileName = "");
 
       // analysis methods (*.ana.h)
-      void    DoLocalCalculation();
-      void    DoLocalCalcWithPackage(const double ptJet);
-      void    DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, ROOT::Math::PtEtaPhiEVector normalization);
-      void    ExtractHistsFromCorr();
-      bool    IsGoodJet(const Types::JetInfo& jet);
-      bool    IsGoodCst(const Types::CstInfo& cst);
-      double  GetWeight(ROOT::Math::PtEtaPhiEVector momentum, int option, optional<ROOT::Math::PtEtaPhiEVector> reference = nullopt);
-      int32_t GetJetPtBin(const double ptJet);
+      void            DoLocalCalculation();
+      void            DoLocalCalcWithPackage(const double ptJet);
+      void            DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, PtEtaPhiEVector normalization);
+      void            ExtractHistsFromCorr();
+      bool            IsGoodJet(const Types::JetInfo& jet);
+      bool            IsGoodCst(const Types::CstInfo& cst);
+      double          GetWeight(PtEtaPhiEVector momentum, int option, optional<PtEtaPhiEVector> reference = nullopt);
+      int32_t         GetJetPtBin(const double ptJet);
+      PtEtaPhiEVector SmearJetMomentum(const Types::JetInfo& jet);
+      PtEtaPhiEVector SmearCstMomentum(const Types::CstInfo& cst);
 
       // configuration
       SEnergyCorrelatorConfig m_config;
@@ -122,6 +127,9 @@ namespace SColdQcdCorrelatorAnalysis {
       TFile*  m_outFile = NULL;
       TFile*  m_inFile  = NULL;
       TChain* m_inChain = NULL;
+
+      // for smearing truth momenta
+      TRandom2* m_rando  = NULL;
 
       // system members
       int m_fCurrent = 0;

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -41,7 +41,7 @@
 // fastjet libraries
 #include <fastjet/PseudoJet.hh>
 // eec library
-#include "/eec/include/EECLongestSide.hh"
+#include <eec/include/EECLongestSide.hh>
 // analysis utilities
 #include <scorrelatorutilities/Tools.h>
 #include <scorrelatorutilities/Types.h>

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -1,12 +1,12 @@
-// ----------------------------------------------------------------------------
-// 'SEnergyCorrelator.h'
-// Derek Anderson
-// 01.20.2023
-//
-// A module to implement Peter Komiske's EEC library
-// in the sPHENIX software stack for the Cold QCD
-// Energy-Energy Correlator analysis.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    SEnergyCorrelator.h
+ *  \authors Derek Anderson, Alex Clarke
+ *  \date    01.20.2023
+ *
+ *  A module to run ENC calculations in the sPHENIX
+ *  software stack for the Cold QCD EEC analysis.
+ */
+/// ---------------------------------------------------------------------------
 
 #ifndef SENERGYCORRELATOR_H
 #define SENERGYCORRELATOR_H
@@ -25,10 +25,10 @@
 #include <TFile.h>
 #include <TChain.h>
 #include <TString.h>
+#include <TRandom2.h>
+#include <TVector3.h>
 #include <TDirectory.h>
 #include <Math/Vector4D.h>
-#include "TVector3.h"
-#include "TRandom2.h"
 // phool utilities
 #include <phool/phool.h>
 #include <phool/getClass.h>
@@ -58,11 +58,20 @@ using namespace std;
 
 namespace SColdQcdCorrelatorAnalysis {
 
-  // SEnergyCorrelator definition ---------------------------------------------
-
+  // --------------------------------------------------------------------------
+  //! N-point energy correlator calculator
+  // --------------------------------------------------------------------------
+  /*! A module to run various N-point energy correlator (ENC) calculations.
+   *  Can run calculations either manually or via P. T. Komiske's EnergyEnergy-
+   *  Correlator package. Also can run either local (in-jet) or global (jet-jet
+   *  or particle-particle) calculations.
+   */
   class SEnergyCorrelator : public SubsysReco {
 
     public:
+
+      // options for ENC weight normalization
+      enum Norm {Pt, Et, E};
 
       // ctor/dtor
       SEnergyCorrelator(SEnergyCorrelatorConfig& config);
@@ -98,12 +107,12 @@ namespace SColdQcdCorrelatorAnalysis {
 
       // analysis methods (*.ana.h)
       void    DoLocalCalculation();
-      double  GetWeight(ROOT::Math::PtEtaPhiEVector momentum, int option, optional<ROOT::Math::PtEtaPhiEVector> reference = nullopt);
       void    DoLocalCalcWithPackage(const double ptJet);
       void    DoLocalCalcManual(const vector<fastjet::PseudoJet> momentum, ROOT::Math::PtEtaPhiEVector normalization);
       void    ExtractHistsFromCorr();
       bool    IsGoodJet(const Types::JetInfo& jet);
       bool    IsGoodCst(const Types::CstInfo& cst);
+      double  GetWeight(ROOT::Math::PtEtaPhiEVector momentum, int option, optional<ROOT::Math::PtEtaPhiEVector> reference = nullopt);
       int32_t GetJetPtBin(const double ptJet);
 
       // configuration
@@ -121,11 +130,11 @@ namespace SColdQcdCorrelatorAnalysis {
       vector<fastjet::PseudoJet> m_jetCstVector;
 
       // output histograms
+      //   - FIXME move these to a dedicate histogram manager
       vector<TH1D*> m_outPackageHistVarDrAxis;
       vector<TH1D*> m_outPackageHistErrDrAxis;
       vector<TH1D*> m_outPackageHistVarLnDrAxis;
       vector<TH1D*> m_outPackageHistErrLnDrAxis;
-
       vector<TH1D*> m_outManualHistErrDrAxis;
       vector<vector<TH2D*>> m_outE3C;
       vector<TH1D*> m_outProjE3C;
@@ -133,16 +142,9 @@ namespace SColdQcdCorrelatorAnalysis {
       // correlators
       vector<fastjet::contrib::eec::EECLongestSide<fastjet::contrib::eec::hist::axis::log>*> m_eecLongSide;
 
-      //Enum for EEC norm
-      enum Norm{
-	Pt,
-	Et,
-	E
-      };
-
       // inputs
-      SEnergyCorrelatorInput       m_input;
-      SEnergyCorrelatorLegacyInput m_legacy;
+      SEnergyCorrelatorInput    m_input;
+      SCorrelatorInputInterface m_interface;
 
   };  // end SEnergyCorrelator
 

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -112,10 +112,8 @@ namespace SColdQcdCorrelatorAnalysis {
       void PrintError(const uint32_t code, const size_t nDrBinEdges = 0, const size_t iDrBin = 0, const string sInFileName = "");
 
       // analysis methods (*.ana.h)
-      void    DoGlobalCalculation();  // TODO
-      void    DoGlobalCalculationWithPackage(const double htEvt);  // TODO
-      void    DoGlobalCalculationManual(const PtEtaPhiEVector& normalization);  // TODO
-      void    DoLocalCalculation();
+      void    RunCalculations();
+      void    DoGlobalCalcManual(const double normGlobal);  // TODO
       void    DoLocalCalcWithPackage(const double ptJet);
       void    DoLocalCalcManual(const PtEtaPhiEVector& normalization);
       void    ExtractHistsFromCorr();

--- a/src/SEnergyCorrelator.h
+++ b/src/SEnergyCorrelator.h
@@ -58,6 +58,7 @@ using namespace std;
 using namespace ROOT::Math;
 
 
+
 namespace SColdQcdCorrelatorAnalysis {
 
   // --------------------------------------------------------------------------

--- a/src/SEnergyCorrelator.io.h
+++ b/src/SEnergyCorrelator.io.h
@@ -1,12 +1,12 @@
-// ----------------------------------------------------------------------------
-// 'SEnergyCorrelator.io.h'
-// Derek Anderson
-// 01.27.2023
-//
-// A module to implement Peter Komiske's EEC library
-// in the sPHENIX software stack for the Cold QCD
-// Energy-Energy Correlator analysis.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    SEnergyCorrelator.io.h
+ *  \authors Derek Anderson, Alex Clarke
+ *  \date    01.20.2023
+ *
+ *  A module to run ENC calculations in the sPHENIX
+ *  software stack for the Cold QCD EEC analysis.
+ */
+/// ---------------------------------------------------------------------------
 
 #pragma once
 
@@ -18,8 +18,11 @@ using namespace findNode;
 
 namespace SColdQcdCorrelatorAnalysis {
 
-  // i/o methods --------------------------------------------------------------
+  // i/o methods ==============================================================
 
+  // --------------------------------------------------------------------------
+  //! Open input files
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::OpenInputFiles() {
 
     // print debug statement
@@ -49,6 +52,9 @@ namespace SColdQcdCorrelatorAnalysis {
 
 
 
+  // --------------------------------------------------------------------------
+  //! Open output files
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::OpenOutputFile() {
 
     // print debug statement
@@ -66,6 +72,9 @@ namespace SColdQcdCorrelatorAnalysis {
 
 
 
+  // --------------------------------------------------------------------------
+  //! Save output
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::SaveOutput() {
 
     // print debug statement
@@ -81,7 +90,7 @@ namespace SColdQcdCorrelatorAnalysis {
 	m_outManualHistErrDrAxis[iPtBin]->Write();
 	if(m_config.doThreePoint){
 	  m_outProjE3C[iPtBin]->Write();
-	  for(size_t jRLBin = 0; jRLBin < m_config.RL_Bins.size(); jRLBin++){
+	  for(size_t jRLBin = 0; jRLBin < m_config.rlBins.size(); jRLBin++){
 	    m_outE3C[iPtBin][jRLBin]->Write();
 	  }
 	}
@@ -89,13 +98,16 @@ namespace SColdQcdCorrelatorAnalysis {
     }
 
     // announce saving
-    if (m_config.isStandalone) PrintMessage(10);
+    PrintMessage(10);
     return;
 
   }  // end 'SaveOutput()'
 
 
 
+  // --------------------------------------------------------------------------
+  //! Close output files
+  // --------------------------------------------------------------------------
   void SEnergyCorrelator::CloseOutputFile() {
 
     // print debug statement

--- a/src/SEnergyCorrelator.io.h
+++ b/src/SEnergyCorrelator.io.h
@@ -111,8 +111,8 @@ namespace SColdQcdCorrelatorAnalysis {
     //   - FIXME move to a dedicated histogram collection
     if (m_config.doGlobalCalc) {
       for (size_t iHtBin = 0; iHtBin < m_config.htEvtBins.size(); iHtBin++) {
-        m_outGlobalHistThetaAxis.at(iHtBin) -> Write();
-        m_outGlobalHistCosThAxis.at(iHtBin) -> Write();
+        m_outGlobalHistDPhiAxis.at(iHtBin)  -> Write();
+        m_outGlobalHistCosDFAxis.at(iHtBin) -> Write();
       }  // end ht bin loop
     }  // end if global
 

--- a/src/SEnergyCorrelator.io.h
+++ b/src/SEnergyCorrelator.io.h
@@ -80,22 +80,41 @@ namespace SColdQcdCorrelatorAnalysis {
     // print debug statement
     if (m_config.isDebugOn) PrintDebug(9);
 
+    // save local output histograms
+    //   - FIXME move to a dedicated histogram collection
     m_outFile -> cd();
-    for (size_t iPtBin = 0; iPtBin < m_config.ptJetBins.size(); iPtBin++) {
-      m_outPackageHistVarDrAxis[iPtBin]   -> Write();
-      m_outPackageHistErrDrAxis[iPtBin]   -> Write();
-      m_outPackageHistVarLnDrAxis[iPtBin] -> Write();
-      m_outPackageHistErrLnDrAxis[iPtBin] -> Write();
-      if(m_config.doManualCalc){
-	m_outManualHistErrDrAxis[iPtBin]->Write();
-	if(m_config.doThreePoint){
-	  m_outProjE3C[iPtBin]->Write();
-	  for(size_t jRLBin = 0; jRLBin < m_config.rlBins.size(); jRLBin++){
-	    m_outE3C[iPtBin][jRLBin]->Write();
-	  }
-	}
-      }
-    }
+    if (m_config.doLocalCalc) {
+      for (size_t iPtBin = 0; iPtBin < m_config.ptJetBins.size(); iPtBin++) {
+
+        // save package histograms
+        if (m_config.doPackageCalc) {
+          m_outPackageHistVarDrAxis[iPtBin]   -> Write();
+          m_outPackageHistErrDrAxis[iPtBin]   -> Write();
+          m_outPackageHistVarLnDrAxis[iPtBin] -> Write();
+          m_outPackageHistErrLnDrAxis[iPtBin] -> Write();
+        }
+
+        // save manual histograms
+        if (m_config.doManualCalc) {
+          m_outManualHistErrDrAxis[iPtBin]->Write();
+          if (m_config.doThreePoint) {
+            m_outProjE3C[iPtBin]->Write();
+            for(size_t jRLBin = 0; jRLBin < m_config.rlBins.size(); jRLBin++){
+              m_outE3C[iPtBin][jRLBin]->Write();
+            }  // end rl bin loop
+          }  // end if three point
+        }  // end if manual
+      } // end pt bin loop
+    }  // end if local
+
+     // save global output histograms
+    //   - FIXME move to a dedicated histogram collection
+    if (m_config.doGlobalCalc) {
+      for (size_t iHtBin = 0; iHtBin < m_config.htEvtBins.size(); iHtBin++) {
+        m_outGlobalHistThetaAxis.at(iHtBin) -> Write();
+        m_outGlobalHistCosThAxis.at(iHtBin) -> Write();
+      }  // end ht bin loop
+    }  // end if global
 
     // announce saving
     PrintMessage(10);

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -171,8 +171,7 @@ namespace SColdQcdCorrelatorAnalysis {
     );
 
     // announce smearing initialization
-    //   - TODO add message 
-    PrintMessage(777);
+    PrintMessage(16);
     return;
 
   }  // end 'InitializeSmearing()'
@@ -317,6 +316,14 @@ namespace SColdQcdCorrelatorAnalysis {
             cout << "     Option " << m_config.subEvtOpt << ": use everything (check what you entered)" << endl;
             break;
         }
+        break;
+
+      case 16:
+        cout << "    Initialized RNG (for smearing, if need be)." << endl;
+        break;
+
+      default:
+        cerr << "WARNING: unknown message code " << code << "!" << endl;
         break;
 
     }  // end switch (code)
@@ -480,7 +487,19 @@ namespace SColdQcdCorrelatorAnalysis {
         break;
 
       case 35:
-        cout << "SEnergyCorrelator::SmearJetMomentum(Types::JetInfo&) smearing jet momentum..." << endl;
+        cout << "SEnergyCorrelator::SmearJetMomentum(ROOT::Math::PtEtaPhiEVector&) smearing jet momentum..." << endl;
+        break;
+
+      case 36:
+        cout << "SEnergyCorrelator::SmearCstMomentum(ROOT::Math::PtEtaPhiEVector&) smearing constituent momentum..." << endl;
+        break;
+
+      case 37:
+        cout << "SEnergyCorrelator::SurvivesEfficiency(double) checking if value survives efficiency..." << endl;
+        break;
+
+      default:
+        cerr << "WARNING: unknown debugging code " << code << "!" << endl;
         break;
 
     }  // end switch (code)
@@ -537,7 +556,7 @@ namespace SColdQcdCorrelatorAnalysis {
         break;
 
       default:
-        cerr << "WARNING: unknown error! code = " << code << endl;
+        cerr << "WARNING: unknown error code " << code << "!" << endl;
         break;
 
     }  // end switch (code)

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -99,10 +99,10 @@ namespace SColdQcdCorrelatorAnalysis {
     // define bins
     //   - FIXME move to a bins database
     map<string, tuple<size_t, float, float>> bins = {
-      {"xi",    make_tuple(100, 0.0, 1.0)},
-      {"phi",   make_tuple(100, 0.0, TMath::Pi()/2.0)},
-      {"dphi",  make_tuple(314, 0.0, TMath::Pi())},
-      {"cosdf", make_tuple(100, 0.0, 1.0)}
+      {"xi",    make_tuple(100, 0.0,  1.0)},
+      {"phi",   make_tuple(100, 0.0,  TMath::Pi()/2.0)},
+      {"dphi",  make_tuple(314, 0.0,  TMath::Pi())},
+      {"cosdf", make_tuple(24,  -1.0, 1.0)}
     };
 
     // loop over pt bins

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -41,8 +41,8 @@ namespace SColdQcdCorrelatorAnalysis {
     m_outManualHistErrDrAxis.clear();
     m_outProjE3C.clear();
     m_outE3C.clear();
-    m_outGlobalHistThetaAxis.clear();
-    m_outGlobalHistCosThAxis.clear();
+    m_outGlobalHistDPhiAxis.clear();
+    m_outGlobalHistCosDFAxis.clear();
     return;
 
   }  // end 'InitializeMembers()'
@@ -101,8 +101,8 @@ namespace SColdQcdCorrelatorAnalysis {
     map<string, tuple<size_t, float, float>> bins = {
       {"xi",    make_tuple(100, 0.0, 1.0)},
       {"phi",   make_tuple(100, 0.0, TMath::Pi()/2.0)},
-      {"theta", make_tuple(314, 0.0, TMath::Pi())},
-      {"costh", make_tuple(100, 0.0, 1.0)}
+      {"dphi",  make_tuple(314, 0.0, TMath::Pi())},
+      {"cosdf", make_tuple(100, 0.0, 1.0)}
     };
 
     // loop over pt bins
@@ -165,29 +165,29 @@ namespace SColdQcdCorrelatorAnalysis {
     }  // end pt bin loop
 
     // create global names
-    const string thetaAxisBase("hTEECThetaAxis_htEvt");
-    const string costhAxisBase("hTEERCosThAxis_htEvt");
+    const string dphiAxisBase("hTEECDPhiAxis_htEvt");
+    const string cosdfAxisBase("hTEERCosDFAxis_htEvt");
 
     // loop over ht bins
     for (size_t iHtBin = 0; iHtBin < m_config.htEvtBins.size(); iHtBin++) {
 
       // construct names
-      const string thetaAxisName = thetaAxisBase + to_string(iHtBin);
-      const string costhAxisName = costhAxisBase + to_string(iHtBin);
+      const string dphiAxisName  = dphiAxisBase + to_string(iHtBin);
+      const string cosdfAxisName = cosdfAxisBase + to_string(iHtBin);
 
       // construct histograms
-      m_outGlobalHistThetaAxis.push_back(
+      m_outGlobalHistDPhiAxis.push_back(
         new TH1D(
-          thetaAxisName.data(),
+          dphiAxisName.data(),
           "",
-          get<0>(bins["theta"]), get<1>(bins["theta"]), get<2>(bins["theta"])
+          get<0>(bins["dphi"]), get<1>(bins["dphi"]), get<2>(bins["dphi"])
         )
       );
-      m_outGlobalHistCosThAxis.push_back(
+      m_outGlobalHistCosDFAxis.push_back(
         new TH1D(
-          costhAxisName.data(),
+          cosdfAxisName.data(),
           "",
-          get<0>(bins["costh"]), get<1>(bins["costh"]), get<2>(bins["costh"])
+          get<0>(bins["cosdf"]), get<1>(bins["cosdf"]), get<2>(bins["cosdf"])
         )
       );
     }  // end ht bin loop

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -232,6 +232,9 @@ namespace SColdQcdCorrelatorAnalysis {
   // --------------------------------------------------------------------------
   void SEnergyCorrelator::InitializeSmearing() {
 
+    // print debug statement
+    if (m_config.isDebugOn) PrintDebug(43);
+
     // grab date & time
     TDatime* time = new TDatime();
 
@@ -541,7 +544,7 @@ namespace SColdQcdCorrelatorAnalysis {
         break;
 
       case 31:
-        cout << "SEnergyCorrelator::DoLocalCalculation() looping over jets and calculating correlators..." << endl;
+        cout << "SEnergyCorrelator::RunCalculations() looping over jets and calculating correlators..." << endl;
         break;
 
       case 32:
@@ -553,7 +556,7 @@ namespace SColdQcdCorrelatorAnalysis {
         break;
 
       case 34:
-        cout << "SEnergyCorrelator::DoLocalCalcWitPackagen() running calculation with EEC package..." << endl;
+        cout << "SEnergyCorrelator::DoLocalCalcWithPackage() running local calculation with EEC package..." << endl;
         break;
 
       case 35:
@@ -566,6 +569,34 @@ namespace SColdQcdCorrelatorAnalysis {
 
       case 37:
         cout << "SEnergyCorrelator::SurvivesEfficiency(double) checking if value survives efficiency..." << endl;
+        break;
+
+      case 38:
+        cout << "SEnergyCorrelator::DoGlobalCalcManual(double) running global calculation..." << endl;
+        break;
+
+      case 39:
+        cout << "SEnergyCorrelator::DoLocalCalcManual(ROOT::Math::PtEtaPhiEVector&) running local calculation manually..." << endl;
+        break;
+
+      case 40:
+        cout << "SEnergyCorrelator::GetWeight(ROOT::Math::PtEtaPhiEVector&, int, optional<ROOT::Math::PtEtaPhiEVector>) getting weight..." << endl;
+        break;
+
+      case 41:
+        cout << "SEnergyCorrelator::GetRM(tuple<double, double, double>&) determining RM..." << endl;
+        break;
+
+      case 42:
+        cout << "SEnergyCorrelator::GetET(TVector3&, TVector3&) calculating et..." << endl;
+        break;
+
+      case 43:
+        cout << "SEnergyCorrelator::InitializeSmearing() initializing smearing utilities..." << endl;
+        break;
+
+      case 44:
+        cout << "SEnergyCorrelator::SEnergyCorrelator(SEnergyCorrelatorConfig&) calling ctor..." << endl;
         break;
 
       default:

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -158,6 +158,28 @@ namespace SColdQcdCorrelatorAnalysis {
 
 
   // --------------------------------------------------------------------------
+  //! Initialize smearing functions and RNGs for smearing
+  // --------------------------------------------------------------------------
+  void SEnergyCorrelator::InitializeSmearing() {
+
+    // grab date & time
+    TDatime* time = new TDatime();
+
+    // and seed RNG w/ date * time
+    m_rando = new TRandom2(
+      (time -> GetDate()) * (time -> GetTime())
+    );
+
+    // announce smearing initialization
+    //   - TODO add message 
+    PrintMessage(777);
+    return;
+
+  }  // end 'InitializeSmearing()'
+
+
+
+  // --------------------------------------------------------------------------
   //! Print messages
   // --------------------------------------------------------------------------
   void SEnergyCorrelator::PrintMessage(
@@ -456,6 +478,11 @@ namespace SColdQcdCorrelatorAnalysis {
       case 34:
         cout << "SEnergyCorrelator::DoLocalCalcWitPackagen() running calculation with EEC package..." << endl;
         break;
+
+      case 35:
+        cout << "SEnergyCorrelator::SmearJetMomentum(Types::JetInfo&) smearing jet momentum..." << endl;
+        break;
+
     }  // end switch (code)
     return;
 

--- a/src/SEnergyCorrelator.sys.h
+++ b/src/SEnergyCorrelator.sys.h
@@ -124,7 +124,7 @@ namespace SColdQcdCorrelatorAnalysis {
 
       // create manual projected 3-point histogram
       m_outProjE3C.push_back(new TH1D(projName.data(), "", m_config.nBinsDr, drBinEdgeArray));
-      m_outProjE3Cback() -> Sumw2();
+      m_outProjE3C.back() -> Sumw2();
 
       // create shape-dependent 3-point histograms
       vector<TH2D*> E3C_tmp;

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -23,7 +23,9 @@ namespace SColdQcdCorrelatorAnalysis {
   struct SEnergyCorrelatorConfig {
 
     // general correlator parameters
-    set<uint32_t>        nPoints    {2};
+    //   - FIXME: nPoints should probably be a set
+    //     or something... TBD...
+    vector<uint32_t>     nPoints    {2};
     pair<double, double> drBinRange {1e-5, 1.};
     uint64_t             nBinsDr    {75};
 

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -50,16 +50,16 @@ namespace SColdQcdCorrelatorAnalysis {
     vector<string> inFileNames   { {} };
 
     // smearing options
-    //   - FIXME theta should be thSmear
-    //   - FIXME modJets should be doJetSmear
-    //   - FIXME modCsts should be doCstSmear
-    bool  modJets    {false};
-    bool  modCsts    {false};
-    bool  doCstEff   {false};
-    float theta      {0};
-    float ptCstSmear {0};
-    float ptJetSmear {0};
-    TF1*  funcEff    {NULL};
+    bool  doJetSmear      {false};  // turn jet smearing on/off
+    bool  doCstSmear      {false};  // turn ANY cst smearing on/off
+    bool  doCstPtSmear    {false};  // smear cst pt by ptCstSmear
+    bool  doCstThetaSmear {false};  // smear cst theta by thCstSmear
+    bool  doCstPhiSmear   {false};  // rotate cst phi around original momentum axis
+    bool  doCstEff        {false};  // apply reco efficiency to csts
+    float ptJetSmear      {0.};     // jet pt smearing width
+    float ptCstSmear      {0.};     // cst pt smearing width
+    float thCstSmear      {0.};     // cst theta smearing width
+    TF1*  funcEff         {NULL};   // cst reconstruction efficiency
 
     // subevent options
     bool        selectSubEvts {false};

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -23,7 +23,7 @@ namespace SColdQcdCorrelatorAnalysis {
   struct SEnergyCorrelatorConfig {
 
     // general correlator parameters
-    vector<uint32_t>     nPoints    { {2} };
+    vector<uint32_t>     nPoints    {2};
     pair<double, double> drBinRange {1e-5, 1.};
     uint64_t             nBinsDr    {75};
 

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -23,7 +23,7 @@ namespace SColdQcdCorrelatorAnalysis {
   struct SEnergyCorrelatorConfig {
 
     // general correlator parameters
-    vector<uint32_t>     nPoints    {2};
+    set<uint32_t>        nPoints    {2};
     pair<double, double> drBinRange {1e-5, 1.};
     uint64_t             nBinsDr    {75};
 

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -36,12 +36,14 @@ namespace SColdQcdCorrelatorAnalysis {
     bool applyCstCuts  {false};
     bool isDebugOn     {false};
     bool isBatchOn     {false};
-    bool doPackageCalc {true};
 
-    // manual calculation options
+    // calculation options
     int  momOption     {0};
     int  normOption    {0};
+    bool doLocalCalc   {true};
+    bool doGlobalCalc  {true};
     bool doManualCalc  {false};
+    bool doPackageCalc {true};
     bool doThreePoint  {false};
 
     // i/o options

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -72,6 +72,7 @@ namespace SColdQcdCorrelatorAnalysis {
     // histogram bins
     vector<pair<double, double>> rlBins    { {{0.0, 1.0}} };
     vector<pair<double, double>> ptJetBins { {{0., 100.}} };
+    vector<pair<double, double>> htEvtBins { {{0., 200.}} };
 
     // acceptance parameters
     pair<Types::JetInfo, Types::JetInfo> jetAccept;

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -1,10 +1,11 @@
-// ----------------------------------------------------------------------------
-// 'SEnergyCorrelatorConfig.h'
-// Derek Anderson
-// 01.18.2024
-//
-// Configuration struct for 'SEnergyCorrelator' module.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    SEnergyCorrelatorConfig.h
+ *  \authors Derek Anderson, Alex Clarke
+ *  \date    01.18.2024
+ *
+ *  Configuration struct for 'SEnergyCorrelator' module.
+ */
+/// ---------------------------------------------------------------------------
 
 #ifndef SENERGYCORRELATORCONFIG_H
 #define SENERGYCORRELATORCONFIG_H
@@ -16,47 +17,54 @@ using namespace std;
 
 namespace SColdQcdCorrelatorAnalysis {
 
-  // SEnergyCorrelatorConfig definition ---------------------------------------
-
+  // --------------------------------------------------------------------------
+  //! User options for module
+  // --------------------------------------------------------------------------
   struct SEnergyCorrelatorConfig {
 
-    // system options
-    int            verbosity     = 0;
-    bool           isDebugOn     = false;
-    bool           isBatchOn     = false;
-    bool           isEmbed       = false;
-    bool           isStandalone  = true;
-    bool           isInTreeTruth = false;
-    bool           isLegacyInput = true;
-    string         moduleName    = "SEnergyCorrelator";
-    string         inNodeName    = "";
-    string         inTreeName    = "";
-    string         outFileName   = "";
-    vector<string> inFileNames;
+    // general correlator parameters
+    vector<uint32_t>     nPoints    { {2} };
+    pair<double, double> drBinRange {1e-5, 1.};
+    uint64_t             nBinsDr    {75};
 
-    // calculation options
-    int                          subEvtOpt     = Const::SubEvtOpt::Everything;
-    bool                         doPackageCalc = true;
-    bool                         applyCstCuts  = false;
-    bool                         selectSubEvts = false;
-    uint64_t                     nBinsDr       = 75;
-    vector<int>                  subEvtsToUse  = {};
-    vector<uint32_t>             nPoints       = {2};
-    vector<pair<double, double>> ptJetBins     = {{0., 100.}};
-    pair<double, double>         drBinRange    = {1e-5, 1.};
-    bool modCsts = false;
-    float effVal = 1;
-    float pTSmear = 0;
-    float theta = 0;
-    bool modJets = false;
-    float jetPtSmear = 0;
+    // basic options
+    int  verbosity    {0};
+    int  subEvtOpt    {Const::SubEvtOpt::Everything};
+    bool isEmbed      {false};
+    bool applyCstCuts {false};
+    bool isDebugOn    {false};
+    bool isBatchOn    {false};
+    bool doPackageCalc {true};
 
-    //Manual Calculation option
-    bool doManualCalc = false;
-    bool doThreePoint = false;
-    vector<pair<double, double>> RL_Bins = {{0.0, 1.0}};
-    int mom_option = 0;
-    int norm_option = 0;
+    // manual calculation options
+    int  momOption     {0};
+    int  normOption    {0};
+    bool doManualCalc  {false};
+    bool doThreePoint  {false};
+
+    // i/o options
+    bool           isInTreeTruth {false};
+    string         moduleName    {"SEnergyCorrelator"};
+    string         inTreeName    {""};
+    string         outFileName   {""};
+    vector<string> inFileNames   { {} };
+
+    // smearing options
+    //   - FIXME theta should be thetaSmear
+    bool  modCsts    {false};
+    bool  modJets    {false};
+    float effVal     {1};
+    float theta      {0};
+    float ptCstSmear {0};
+    float ptJetSmear {0};
+
+    // subevent options
+    bool        selectSubEvts {false};
+    vector<int> subEvtsToUse  { {} };
+
+    // histogram bins
+    vector<pair<double, double>> rlBins    { {{0.0, 1.0}} };
+    vector<pair<double, double>> ptJetBins { {{0., 100.}} };
 
     // acceptance parameters
     pair<Types::JetInfo, Types::JetInfo> jetAccept;

--- a/src/SEnergyCorrelatorConfig.h
+++ b/src/SEnergyCorrelatorConfig.h
@@ -28,12 +28,12 @@ namespace SColdQcdCorrelatorAnalysis {
     uint64_t             nBinsDr    {75};
 
     // basic options
-    int  verbosity    {0};
-    int  subEvtOpt    {Const::SubEvtOpt::Everything};
-    bool isEmbed      {false};
-    bool applyCstCuts {false};
-    bool isDebugOn    {false};
-    bool isBatchOn    {false};
+    int  verbosity     {0};
+    int  subEvtOpt     {Const::SubEvtOpt::Everything};
+    bool isEmbed       {false};
+    bool applyCstCuts  {false};
+    bool isDebugOn     {false};
+    bool isBatchOn     {false};
     bool doPackageCalc {true};
 
     // manual calculation options
@@ -50,13 +50,16 @@ namespace SColdQcdCorrelatorAnalysis {
     vector<string> inFileNames   { {} };
 
     // smearing options
-    //   - FIXME theta should be thetaSmear
-    bool  modCsts    {false};
+    //   - FIXME theta should be thSmear
+    //   - FIXME modJets should be doJetSmear
+    //   - FIXME modCsts should be doCstSmear
     bool  modJets    {false};
-    float effVal     {1};
+    bool  modCsts    {false};
+    bool  doCstEff   {false};
     float theta      {0};
     float ptCstSmear {0};
     float ptJetSmear {0};
+    TF1*  funcEff    {NULL};
 
     // subevent options
     bool        selectSubEvts {false};

--- a/src/SEnergyCorrelatorInput.h
+++ b/src/SEnergyCorrelatorInput.h
@@ -1,12 +1,12 @@
-// ----------------------------------------------------------------------------
-// 'SEnergyCorrelatorInput.h'
-// Derek Anderson
-// 03.15.2023
-//
-// This struct collects the old branches from the
-// input jet trees and methods for converting
-// to-from the old-to-new input.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file    SEnergyCorrelatorInput.h
+ *  \authors Derek Anderson, Alex Clarke
+ *  \date    03.15.2023
+ *
+ *  A set of structs to define module input
+ *  and how to interface with the input trees.
+ */
+/// ---------------------------------------------------------------------------
 
 #ifndef SENERGYCORRELATORINPUT_H
 #define SENERGYCORRELATORINPUT_H
@@ -18,8 +18,9 @@ using namespace std;
 
 namespace SColdQcdCorrelatorAnalysis {
 
-  // input definition ---------------------------------------------------------
-
+  // --------------------------------------------------------------------------
+  //! Module input
+  // --------------------------------------------------------------------------
   struct SEnergyCorrelatorInput {
 
     // event level info
@@ -30,26 +31,27 @@ namespace SColdQcdCorrelatorAnalysis {
     vector<Types::JetInfo>         jets;
     vector<vector<Types::CstInfo>> csts; 
 
+    // ------------------------------------------------------------------------
+    //! Reset variables
+    // ------------------------------------------------------------------------
     void Reset() {
+
       reco.Reset();
       gen.Reset();
       jets.clear();
       csts.clear();
       return;
-    }  // end 'Reset()'
 
-    void SetChainAddresses(TChain* chain, const bool isInTreeTruth = true) {
-      /* TODO fill in */
-      return;
-    }  // end 'SetChainAddresses(TChain*, bool)'
+    }  // end 'Reset()'
 
   };  // end SEnergyCorrelatorInput 
 
 
 
-  // legacy input definition --------------------------------------------------
-
-  struct SEnergyCorrelatorLegacyInput {
+  // --------------------------------------------------------------------------
+  //! Interface to input tree
+  // --------------------------------------------------------------------------
+  struct SCorrelatorInputInterface {
 
     // input truth tree addresses
     int                  evtNumChrgPars = numeric_limits<int>::min();
@@ -87,9 +89,11 @@ namespace SColdQcdCorrelatorAnalysis {
     vector<vector<double>>* cstEta     = NULL;
     vector<vector<double>>* cstPhi     = NULL;
 
-
-
+    // ------------------------------------------------------------------------
+    //! Reset variables
+    // ------------------------------------------------------------------------
     void Reset() {
+
       evtNumChrgPars = numeric_limits<int>::min();
       evtSumPar      = numeric_limits<double>::min();
       partonID       = make_pair(numeric_limits<int>::min(),    numeric_limits<int>::min());
@@ -121,11 +125,14 @@ namespace SColdQcdCorrelatorAnalysis {
       cstEta         = NULL;
       cstPhi         = NULL;
       return;
+
     }  // end 'Reset()'
 
-
-
+    // ------------------------------------------------------------------------
+    //! Set tree addresses
+    // ------------------------------------------------------------------------
     void SetChainAddresses(TChain* chain, const bool isInTreeTruth = true) {
+
       if (isInTreeTruth) {
         chain -> SetBranchAddress("Parton3_ID",   &partonID.first);
         chain -> SetBranchAddress("Parton4_ID",   &partonID.second);
@@ -162,11 +169,17 @@ namespace SColdQcdCorrelatorAnalysis {
       chain -> SetBranchAddress("CstEta",     &cstEta);
       chain -> SetBranchAddress("CstPhi",     &cstPhi);
       return;
+
     }  // end 'SetChainAddresses(TChain*)'
 
-
-
-    void SetCorrelatorInput(SEnergyCorrelatorInput& input, const bool isInTreeTruth = true, optional<bool> isEmbed = nullopt) {
+    // ------------------------------------------------------------------------
+    //! Collect tree values into input variables
+    // ------------------------------------------------------------------------
+    void SetCorrelatorInput(
+      SEnergyCorrelatorInput& input,
+      const bool isInTreeTruth = true,
+      optional<bool> isEmbed = nullopt
+    ) {
 
       // make sure container is empty
       input.Reset();
@@ -258,13 +271,12 @@ namespace SColdQcdCorrelatorAnalysis {
       }  // end jet loop
       return;
 
-    }  // end 'SetCorrelatorInput(SEnergyCorrelatorInput&)'
+    }  // end 'SetCorrelatorInput(SEnergyCorrelatorInput&, bool, optional<bool>)'
 
-  };  // end SEnergyCorrelatorLegacyInput
+  };  // end SCorrelatorInputInterface
 
 }  // end SColdQcdCorrelatorAnalysis namespace
 
 #endif
 
 // end ------------------------------------------------------------------------
-

--- a/src/SEnergyCorrelatorInput.h
+++ b/src/SEnergyCorrelatorInput.h
@@ -24,8 +24,8 @@ namespace SColdQcdCorrelatorAnalysis {
   struct SEnergyCorrelatorInput {
 
     // event level info
-    Types::RecoInfo reco;
-    Types::GenInfo  gen;
+    Types::REvtInfo reco;
+    Types::GEvtInfo gen;
 
     // jet and constituent info
     vector<Types::JetInfo>         jets;

--- a/src/SEnergyCorrelatorInput.h
+++ b/src/SEnergyCorrelatorInput.h
@@ -158,7 +158,7 @@ namespace SColdQcdCorrelatorAnalysis {
       chain -> SetBranchAddress("CstZ",       &cstZ);
       chain -> SetBranchAddress("CstDr",      &cstDr);
       chain -> SetBranchAddress("CstEnergy",  &cstEnergy);
-      chain -> SetBranchAddress("CstJt",      &cstPt);
+      chain -> SetBranchAddress("CstPt",      &cstPt);
       chain -> SetBranchAddress("CstEta",     &cstEta);
       chain -> SetBranchAddress("CstPhi",     &cstPhi);
       return;

--- a/src/SEnergyCorrelatorLinkDef.h
+++ b/src/SEnergyCorrelatorLinkDef.h
@@ -1,12 +1,13 @@
-// ----------------------------------------------------------------------------
-// 'SEnergyCorrelatorLinkDef.h'
-// Derek Anderson
-// 01.27.2023
-//
-// A module to implement Peter Komiske's EEC library
-// in the sPHENIX software stack for the Cold QCD
-// Energy-Energy Correlator analysis.
-// ----------------------------------------------------------------------------
+/// ---------------------------------------------------------------------------
+/*! \file   SEnergyCorrelatorLinkDef.h
+ *  \author Derek Anderson
+ *  \date   01.27.2023
+ *
+ *  A module to implement Peter Komiske's EEC library
+ *  in the sPHENIX software stack for the Cold QCD
+ *  Energy-Energy Correlator analysis.
+ */
+/// ---------------------------------------------------------------------------
 
 #ifdef __CINT__
 


### PR DESCRIPTION
This PR prepares the module for running TEEC calculations. Along the way, it makes several minor changes including making sure the formatting is consistent across the codebase, general code hygiene/clean up, refactoring things by integrating concepts from other projects (esp. for histogram managing), etc.

# Changes
- [x] Doxygenated comments
- [x] Alex is accredited in all relevant files
- [x] Not-legacy input is deprecated: "legacy" input struct renamed to reflect that it now defines the interface to the input tree
- [x] Complex mode is completely removed
- [x] Move kinematic smearing to a dedicated function
- [x] Add "Global" calculations

# TO-DO

There are a couple items that I'll defer to a following PR.
- [ ] Move histogram creation to a `PHEnergyCorrelator`-style histogram manager
- [ ] Finish adding piping for multiple points per calculation